### PR TITLE
Add module `tree()` methods

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -162,6 +162,7 @@ COMPOSITOR_CONFIG = TreeTypeConfig(
     ],
     manually_defined=(
         "MenuSwitch",
+        "Filter",
         "tree",
     ),
     class_name_prefix_strips=[
@@ -487,6 +488,7 @@ class NodeInfo:
                 "data_type",
                 "input_type",
                 "attribute_type",
+                "type",
             ]:
                 continue
 

--- a/generate.py
+++ b/generate.py
@@ -117,6 +117,7 @@ GEOMETRY_CONFIG = TreeTypeConfig(
         "FieldVariance",
         "Compare",
         "AttributeStatistic",
+        "tree",
     ),
     class_name_prefix_strips=[
         "GeometryNode",
@@ -134,7 +135,13 @@ SHADER_CONFIG = TreeTypeConfig(
         "Frame",
         "Reroute",
     ],
-    manually_defined=("MenuSwitch", "RepeatInput", "RepeatOutput", "RepeatZone"),
+    manually_defined=(
+        "MenuSwitch",
+        "RepeatInput",
+        "RepeatOutput",
+        "RepeatZone",
+        "tree",
+    ),
     class_name_prefix_strips=[
         "ShaderNode",
         "Node",
@@ -151,7 +158,10 @@ COMPOSITOR_CONFIG = TreeTypeConfig(
         "Cryptomatte",
         "Image",
     ],
-    manually_defined=("MenuSwitch",),
+    manually_defined=(
+        "MenuSwitch",
+        "tree",
+    ),
     class_name_prefix_strips=[
         "CompositorNode",
         "Node",

--- a/generate.py
+++ b/generate.py
@@ -162,7 +162,6 @@ COMPOSITOR_CONFIG = TreeTypeConfig(
     ],
     manually_defined=(
         "MenuSwitch",
-        "Filter",
         "tree",
     ),
     class_name_prefix_strips=[
@@ -374,6 +373,9 @@ class NodeInfo:
     properties: list[PropertyInfo]
     domain_sockets: dict[str, list[SocketInfo]]
     tree_types: list[str] = field(default_factory=list)
+    # Per-value socket snapshots for any input socket named "Type" that is a MENU.
+    # Keyed by the socket identifier; each entry mirrors EnumInfo used for properties.
+    type_socket_enums: list[EnumInfo] = field(default_factory=list)
 
     @property
     def node_docs_url(self) -> str | None:
@@ -495,11 +497,8 @@ class NodeInfo:
             # assert operation_enum.enum_items
             for enum in prop.enum_items:
                 # Handle special cases for better naming
-                method_name = (
-                    enum.name.lower()
-                    .replace(" ", "_")
-                    .replace("-", "_")
-                    .replace("4x4_matrix", "matrix")
+                method_name = normalize_name(
+                    enum.name.replace("4x4_matrix", "matrix")
                     .replace("8_bit_integer", "int8")
                     .replace("2d_vector", "vector2")
                 )
@@ -558,12 +557,83 @@ class NodeInfo:
                 else:
                     call_params_str = operation_param
 
+                docstring = f"Create {self.name} with operation '{enum.name}'."
+                if enum.description:
+                    docstring += f" {enum.description}"
+
                 method = f'''
     @classmethod
     def {method_name}(
         {params_str}
     ) -> "{cls_name}":
-        """Create {self.name} with operation '{enum.name}'."""
+        """{docstring}"""
+        return cls({call_params_str})'''
+
+                methods.append(method)
+
+        # Generate classmethods for input sockets named "type" that are MENU sockets.
+        # Uses per-value socket snapshots collected during introspection so that methods
+        # only expose the sockets that are actually visible for that type value.
+        type_param_name = "type"
+        if self.type_socket_enums:
+            for enum in self.type_socket_enums:
+                item_value = enum.identifier
+                method_name = normalize_name(item_value)
+                if method_name == "and":
+                    method_name = "l_and"
+                elif method_name == "or":
+                    method_name = "l_or"
+                elif method_name == "not":
+                    method_name = "l_not"
+
+                input_params = ["cls"]
+                call_params = []
+
+                all_identifiers = [s.identifier for s in enum.sockets]
+                sockets_use_same_name = (
+                    all(ident == all_identifiers[0] for ident in all_identifiers)
+                    if all_identifiers
+                    else False
+                )
+
+                for socket in enum.sockets:
+                    socket_name = get_socket_param_name(socket, sockets_use_same_name)
+                    if socket_name.startswith("min"):
+                        param_name = "min"
+                    elif socket_name.startswith("max"):
+                        param_name = "max"
+                    else:
+                        param_name = socket_name
+                    param_name = param_name.replace("_float", "").replace("_vector", "")
+
+                    if (
+                        param_name
+                        and param_name != ""
+                        and param_name != type_param_name
+                    ):
+                        input_params.append(
+                            f"{param_name}: {socket.type_hint} = {format_python_value(socket.default_value)}"
+                        )
+                        call_params.append(f"{socket_name}={param_name}")
+
+                params_str = ",\n        ".join(input_params)
+                call_params_str = ", ".join(call_params)
+                type_call_param = f'{type_param_name}="{item_value}"'
+                if call_params_str:
+                    call_params_str = f"{call_params_str}, {type_call_param}"
+                else:
+                    call_params_str = type_call_param
+
+                docstring = f"Create {self.name} node with type '{item_value}'."
+                if enum.description:
+                    docstring += f" {enum.description}"
+
+                method = f'''
+    @classmethod
+    def {method_name}(
+        {params_str}
+    ) -> "{cls_name}":
+        """{docstring}"""
         return cls({call_params_str})'''
 
                 methods.append(method)
@@ -794,6 +864,46 @@ def introspect_node(node_type: type, tree_type: str) -> NodeInfo | None:
         outputs = collect_socket_info(node.outputs, hidden=True, is_output=True)
         properties = collect_property_info(node, node_type)
 
+        # Collect per-value socket snapshots for any input socket named "Type"
+        # that is a MENU.  Mirrors what collect_property_info does for enum properties.
+        type_socket_enums: list[EnumInfo] = []
+        for live_socket in node.inputs:
+            if normalize_name(live_socket.identifier) != "type":
+                continue
+            if live_socket.type != "MENU":
+                continue
+            menu_items = _collect_socket_menu_items(live_socket)
+            if not menu_items:
+                continue
+            # Build identifier → description map from the socket's RNA enum items.
+            rna_descriptions: dict[str, str] = {}
+            try:
+                enum_prop = live_socket.bl_rna.properties.get("default_value")
+                if enum_prop and hasattr(enum_prop, "enum_items"):
+                    for rna_item in enum_prop.enum_items:
+                        rna_descriptions[rna_item.identifier] = rna_item.description
+            except Exception:
+                pass
+
+            saved = live_socket.default_value
+            for raw_item in menu_items:
+                item_value = raw_item.strip("'\"")
+                try:
+                    live_socket.default_value = item_value
+                    type_socket_enums.append(
+                        EnumInfo(
+                            identifier=item_value,
+                            name=item_value,
+                            description=rna_descriptions.get(item_value, ""),
+                            sockets=collect_socket_info(node.inputs),
+                        )
+                    )
+                except Exception:
+                    pass
+                finally:
+                    live_socket.default_value = saved
+            break  # only handle the first "Type" socket
+
         # Clean up
         bpy.data.node_groups.remove(temp_tree)
 
@@ -806,6 +916,7 @@ def introspect_node(node_type: type, tree_type: str) -> NodeInfo | None:
             outputs=outputs,
             properties=properties,
             domain_sockets={},
+            type_socket_enums=type_socket_enums,
         )
 
     except RuntimeError as e:

--- a/generate.py
+++ b/generate.py
@@ -140,7 +140,9 @@ SHADER_CONFIG = TreeTypeConfig(
         "RepeatInput",
         "RepeatOutput",
         "RepeatZone",
+        "Attribute",
         "tree",
+        "material",
     ),
     class_name_prefix_strips=[
         "ShaderNode",
@@ -484,6 +486,7 @@ class NodeInfo:
                 "domain",
                 "data_type",
                 "input_type",
+                "attribute_type",
             ]:
                 continue
 

--- a/src/nodebpy/__init__.py
+++ b/src/nodebpy/__init__.py
@@ -1,10 +1,6 @@
 from . import nodes, screenshot, sockets
 from .builder import TreeBuilder
 from .nodes import compositor, geometry, shader
-from .screenshot import (
-    generate_mermaid_diagram,
-    save_mermaid_diagram,
-)
 
 __all__ = [
     "nodes",
@@ -14,6 +10,4 @@ __all__ = [
     "sockets",
     "screenshot",
     "TreeBuilder",
-    "generate_mermaid_diagram",
-    "save_mermaid_diagram",
 ]

--- a/src/nodebpy/builder/__init__.py
+++ b/src/nodebpy/builder/__init__.py
@@ -4,6 +4,7 @@ Public names are re-exported here. Old names (NodeBuilder, SocketLinker,
 SocketBase) are kept as aliases for backward compatibility.
 """
 
+from ._utils import SocketError, denormalize_name, normalize_name
 from .accessor import SocketAccessor
 from .interface import (
     InterfaceSocket,
@@ -55,12 +56,12 @@ from .socket import (
 )
 from .tree import (
     InputInterfaceContext,
+    MaterialBuilder,
     OutputInterfaceContext,
     PanelContext,
     SocketContext,
     TreeBuilder,
 )
-from ._utils import SocketError, denormalize_name, normalize_name
 
 # Backward-compatible aliases for hand-written code that uses the old names.
 NodeBuilder = BaseNode
@@ -70,6 +71,7 @@ SocketBase = InterfaceSocket
 __all__ = [
     # Core
     "TreeBuilder",
+    "MaterialBuilder",
     "BaseNode",
     "Socket",
     "SocketAccessor",

--- a/src/nodebpy/builder/tree.py
+++ b/src/nodebpy/builder/tree.py
@@ -326,3 +326,25 @@ class TreeBuilder:
         node = self.tree.nodes.new(name)
         node.hide = self.collapse
         return node
+
+
+class MaterialBuilder(TreeBuilder):
+    def __init__(
+        self,
+        name: str = "New Material",
+        *,
+        collapse: bool = False,
+        arrange: Literal["sugiyama", "simple"] | None = "sugiyama",
+        fake_user: bool = False,
+        ignore_visibility: bool = False,
+    ):
+        self.material = bpy.data.materials.new(name)
+        self.material.use_fake_user = fake_user
+        assert self.material.node_tree
+        super().__init__(
+            self.material.node_tree,
+            collapse=collapse,
+            arrange=arrange,
+            fake_user=fake_user,
+            ignore_visibility=ignore_visibility,
+        )

--- a/src/nodebpy/nodes/compositor/__init__.py
+++ b/src/nodebpy/nodes/compositor/__init__.py
@@ -2,7 +2,6 @@
 
 from .manual import (
     MenuSwitch,
-    Filter,
     tree,
 )
 from ..geometry.color import (
@@ -66,6 +65,7 @@ from .filter import (
     Despeckle,
     Dilateerode,
     DirectionalBlur,
+    Filter,
     Glare,
     Inpaint,
     Kuwahara,

--- a/src/nodebpy/nodes/compositor/__init__.py
+++ b/src/nodebpy/nodes/compositor/__init__.py
@@ -2,6 +2,7 @@
 
 from .manual import (
     MenuSwitch,
+    Filter,
     tree,
 )
 from ..geometry.color import (
@@ -65,7 +66,6 @@ from .filter import (
     Despeckle,
     Dilateerode,
     DirectionalBlur,
-    Filter,
     Glare,
     Inpaint,
     Kuwahara,

--- a/src/nodebpy/nodes/compositor/__init__.py
+++ b/src/nodebpy/nodes/compositor/__init__.py
@@ -2,6 +2,7 @@
 
 from .manual import (
     MenuSwitch,
+    tree,
 )
 from ..geometry.color import (
     Gamma,
@@ -246,4 +247,5 @@ __all__ = (
     "VoronoiTexture",
     "WaveTexture",
     "WhiteNoiseTexture",
+    "tree",
 )

--- a/src/nodebpy/nodes/compositor/color.py
+++ b/src/nodebpy/nodes/compositor/color.py
@@ -41,6 +41,57 @@ class AlphaOver(NodeBuilder):
 
         self._establish_links(**key_args)
 
+    @classmethod
+    def over(
+        cls,
+        background: InputColor = None,
+        foreground: InputColor = None,
+        fac: InputFloat = 1.0,
+        straight_alpha: InputBoolean = False,
+    ) -> "AlphaOver":
+        """Create Alpha Over node with type 'Over'."""
+        return cls(
+            background=background,
+            foreground=foreground,
+            fac=fac,
+            straight_alpha=straight_alpha,
+            type="Over",
+        )
+
+    @classmethod
+    def disjoint_over(
+        cls,
+        background: InputColor = None,
+        foreground: InputColor = None,
+        fac: InputFloat = 1.0,
+        straight_alpha: InputBoolean = False,
+    ) -> "AlphaOver":
+        """Create Alpha Over node with type 'Disjoint Over'."""
+        return cls(
+            background=background,
+            foreground=foreground,
+            fac=fac,
+            straight_alpha=straight_alpha,
+            type="Disjoint Over",
+        )
+
+    @classmethod
+    def conjoint_over(
+        cls,
+        background: InputColor = None,
+        foreground: InputColor = None,
+        fac: InputFloat = 1.0,
+        straight_alpha: InputBoolean = False,
+    ) -> "AlphaOver":
+        """Create Alpha Over node with type 'Conjoint Over'."""
+        return cls(
+            background=background,
+            foreground=foreground,
+            fac=fac,
+            straight_alpha=straight_alpha,
+            type="Conjoint Over",
+        )
+
     @property
     def i_background(self) -> Socket:
         """Input socket: Background"""
@@ -173,6 +224,77 @@ class ColorBalance(NodeBuilder):
         self.input_whitepoint = input_whitepoint
         self.output_whitepoint = output_whitepoint
         self._establish_links(**key_args)
+
+    @classmethod
+    def lift_gamma_gain(
+        cls,
+        image: InputColor = None,
+        fac: InputFloat = 1.0,
+        base_lift: InputFloat = 0.0,
+        color_lift: InputColor = None,
+        base_gamma: InputFloat = 1.0,
+        color_gamma: InputColor = None,
+        base_gain: InputFloat = 1.0,
+        color_gain: InputColor = None,
+    ) -> "ColorBalance":
+        """Create Color Balance node with type 'Lift/Gamma/Gain'."""
+        return cls(
+            image=image,
+            fac=fac,
+            base_lift=base_lift,
+            color_lift=color_lift,
+            base_gamma=base_gamma,
+            color_gamma=color_gamma,
+            base_gain=base_gain,
+            color_gain=color_gain,
+            type="Lift/Gamma/Gain",
+        )
+
+    @classmethod
+    def offset_power_slope_asc_cdl(
+        cls,
+        image: InputColor = None,
+        fac: InputFloat = 1.0,
+        base_offset: InputFloat = 0.0,
+        color_offset: InputColor = None,
+        base_power: InputFloat = 1.0,
+        color_power: InputColor = None,
+        base_slope: InputFloat = 1.0,
+        color_slope: InputColor = None,
+    ) -> "ColorBalance":
+        """Create Color Balance node with type 'Offset/Power/Slope (ASC-CDL)'."""
+        return cls(
+            image=image,
+            fac=fac,
+            base_offset=base_offset,
+            color_offset=color_offset,
+            base_power=base_power,
+            color_power=color_power,
+            base_slope=base_slope,
+            color_slope=color_slope,
+            type="Offset/Power/Slope (ASC-CDL)",
+        )
+
+    @classmethod
+    def white_point(
+        cls,
+        image: InputColor = None,
+        fac: InputFloat = 1.0,
+        input_temperature: InputFloat = 6500.0,
+        input_tint: InputFloat = 10.0,
+        output_temperature: InputFloat = 6500.0,
+        output_tint: InputFloat = 10.0,
+    ) -> "ColorBalance":
+        """Create Color Balance node with type 'White Point'."""
+        return cls(
+            image=image,
+            fac=fac,
+            input_temperature=input_temperature,
+            input_tint=input_tint,
+            output_temperature=output_temperature,
+            output_tint=output_tint,
+            type="White Point",
+        )
 
     @property
     def i_image(self) -> Socket:
@@ -870,6 +992,36 @@ class Tonemap(NodeBuilder):
         }
 
         self._establish_links(**key_args)
+
+    @classmethod
+    def r_d_photoreceptor(
+        cls,
+        image: InputColor = None,
+        intensity: InputFloat = 0.0,
+        contrast: InputFloat = 0.0,
+        light_adaptation: InputFloat = 0.0,
+        chromatic_adaptation: InputFloat = 0.0,
+    ) -> "Tonemap":
+        """Create Tonemap node with type 'R/D Photoreceptor'."""
+        return cls(
+            image=image,
+            intensity=intensity,
+            contrast=contrast,
+            light_adaptation=light_adaptation,
+            chromatic_adaptation=chromatic_adaptation,
+            type="R/D Photoreceptor",
+        )
+
+    @classmethod
+    def rh_simple(
+        cls,
+        image: InputColor = None,
+        key: InputFloat = 0.18,
+        balance: InputFloat = 1.0,
+        gamma: InputFloat = 1.0,
+    ) -> "Tonemap":
+        """Create Tonemap node with type 'Rh Simple'."""
+        return cls(image=image, key=key, balance=balance, gamma=gamma, type="Rh Simple")
 
     @property
     def i_image(self) -> Socket:

--- a/src/nodebpy/nodes/compositor/converter.py
+++ b/src/nodebpy/nodes/compositor/converter.py
@@ -43,6 +43,16 @@ class AlphaConvert(NodeBuilder):
 
         self._establish_links(**key_args)
 
+    @classmethod
+    def to_premultiplied(cls, image: InputColor = None) -> "AlphaConvert":
+        """Create Alpha Convert node with type 'To Premultiplied'."""
+        return cls(image=image, type="To Premultiplied")
+
+    @classmethod
+    def to_straight(cls, image: InputColor = None) -> "AlphaConvert":
+        """Create Alpha Convert node with type 'To Straight'."""
+        return cls(image=image, type="To Straight")
+
     @property
     def i_image(self) -> Socket:
         """Input socket: Image"""
@@ -760,14 +770,14 @@ class RelativeToPixel(NodeBuilder):
     def float(
         cls, float_value: InputFloat = 0.0, image: InputColor = None
     ) -> "RelativeToPixel":
-        """Create Relative To Pixel with operation 'Float'."""
+        """Create Relative To Pixel with operation 'Float'. Float value"""
         return cls(data_type="FLOAT", float_value=float_value, image=image)
 
     @classmethod
     def vector(
         cls, vector_value: InputVector = None, image: InputColor = None
     ) -> "RelativeToPixel":
-        """Create Relative To Pixel with operation 'Vector'."""
+        """Create Relative To Pixel with operation 'Vector'. Vector value"""
         return cls(data_type="VECTOR", vector_value=vector_value, image=image)
 
     @property
@@ -898,6 +908,20 @@ class SetAlpha(NodeBuilder):
         key_args = {"Image": image, "Alpha": alpha, "Type": type}
 
         self._establish_links(**key_args)
+
+    @classmethod
+    def apply_mask(
+        cls, image: InputColor = None, alpha: InputFloat = 1.0
+    ) -> "SetAlpha":
+        """Create Set Alpha node with type 'Apply Mask'."""
+        return cls(image=image, alpha=alpha, type="Apply Mask")
+
+    @classmethod
+    def replace_alpha(
+        cls, image: InputColor = None, alpha: InputFloat = 1.0
+    ) -> "SetAlpha":
+        """Create Set Alpha node with type 'Replace Alpha'."""
+        return cls(image=image, alpha=alpha, type="Replace Alpha")
 
     @property
     def i_image(self) -> Socket:

--- a/src/nodebpy/nodes/compositor/distort.py
+++ b/src/nodebpy/nodes/compositor/distort.py
@@ -294,6 +294,32 @@ class LensDistortion(NodeBuilder):
 
         self._establish_links(**key_args)
 
+    @classmethod
+    def radial(
+        cls,
+        image: InputColor = None,
+        distortion: InputFloat = 0.0,
+        dispersion: InputFloat = 0.0,
+        jitter: InputBoolean = False,
+        fit: InputBoolean = False,
+    ) -> "LensDistortion":
+        """Create Lens Distortion node with type 'Radial'."""
+        return cls(
+            image=image,
+            distortion=distortion,
+            dispersion=dispersion,
+            jitter=jitter,
+            fit=fit,
+            type="Radial",
+        )
+
+    @classmethod
+    def horizontal(
+        cls, image: InputColor = None, dispersion: InputFloat = 0.0
+    ) -> "LensDistortion":
+        """Create Lens Distortion node with type 'Horizontal'."""
+        return cls(image=image, dispersion=dispersion, type="Horizontal")
+
     @property
     def i_image(self) -> Socket:
         """Input socket: Image"""
@@ -406,6 +432,16 @@ class MovieDistortion(NodeBuilder):
         key_args = {"Image": image, "Type": type}
 
         self._establish_links(**key_args)
+
+    @classmethod
+    def undistort(cls, image: InputColor = None) -> "MovieDistortion":
+        """Create Movie Distortion node with type 'Undistort'."""
+        return cls(image=image, type="Undistort")
+
+    @classmethod
+    def distort(cls, image: InputColor = None) -> "MovieDistortion":
+        """Create Movie Distortion node with type 'Distort'."""
+        return cls(image=image, type="Distort")
 
     @property
     def i_image(self) -> Socket:
@@ -592,6 +628,88 @@ class Scale(NodeBuilder):
         }
 
         self._establish_links(**key_args)
+
+    @classmethod
+    def relative(
+        cls,
+        image: InputColor = None,
+        x: InputFloat = 1.0,
+        y: InputFloat = 1.0,
+        interpolation: InputMenu
+        | Literal["Nearest", "Bilinear", "Bicubic", "Anisotropic"] = "Bilinear",
+        extension_x: InputMenu | Literal["Clip", "Extend", "Repeat"] = "Clip",
+        extension_y: InputMenu | Literal["Clip", "Extend", "Repeat"] = "Clip",
+    ) -> "Scale":
+        """Create Scale node with type 'Relative'."""
+        return cls(
+            image=image,
+            x=x,
+            y=y,
+            interpolation=interpolation,
+            extension_x=extension_x,
+            extension_y=extension_y,
+            type="Relative",
+        )
+
+    @classmethod
+    def absolute(
+        cls,
+        image: InputColor = None,
+        x: InputFloat = 1.0,
+        y: InputFloat = 1.0,
+        interpolation: InputMenu
+        | Literal["Nearest", "Bilinear", "Bicubic", "Anisotropic"] = "Bilinear",
+        extension_x: InputMenu | Literal["Clip", "Extend", "Repeat"] = "Clip",
+        extension_y: InputMenu | Literal["Clip", "Extend", "Repeat"] = "Clip",
+    ) -> "Scale":
+        """Create Scale node with type 'Absolute'."""
+        return cls(
+            image=image,
+            x=x,
+            y=y,
+            interpolation=interpolation,
+            extension_x=extension_x,
+            extension_y=extension_y,
+            type="Absolute",
+        )
+
+    @classmethod
+    def scene_size(
+        cls,
+        image: InputColor = None,
+        interpolation: InputMenu
+        | Literal["Nearest", "Bilinear", "Bicubic", "Anisotropic"] = "Bilinear",
+        extension_x: InputMenu | Literal["Clip", "Extend", "Repeat"] = "Clip",
+        extension_y: InputMenu | Literal["Clip", "Extend", "Repeat"] = "Clip",
+    ) -> "Scale":
+        """Create Scale node with type 'Scene Size'."""
+        return cls(
+            image=image,
+            interpolation=interpolation,
+            extension_x=extension_x,
+            extension_y=extension_y,
+            type="Scene Size",
+        )
+
+    @classmethod
+    def render_size(
+        cls,
+        image: InputColor = None,
+        frame_type: InputMenu | Literal["Stretch", "Fit", "Crop"] = "Stretch",
+        interpolation: InputMenu
+        | Literal["Nearest", "Bilinear", "Bicubic", "Anisotropic"] = "Bilinear",
+        extension_x: InputMenu | Literal["Clip", "Extend", "Repeat"] = "Clip",
+        extension_y: InputMenu | Literal["Clip", "Extend", "Repeat"] = "Clip",
+    ) -> "Scale":
+        """Create Scale node with type 'Render Size'."""
+        return cls(
+            image=image,
+            frame_type=frame_type,
+            interpolation=interpolation,
+            extension_x=extension_x,
+            extension_y=extension_y,
+            type="Render Size",
+        )
 
     @property
     def i_image(self) -> Socket:

--- a/src/nodebpy/nodes/compositor/filter.py
+++ b/src/nodebpy/nodes/compositor/filter.py
@@ -658,56 +658,6 @@ class DirectionalBlur(NodeBuilder):
         return self.outputs.get("Image")
 
 
-class Filter(NodeBuilder):
-    """
-    Apply common image enhancement filters
-    """
-
-    _bl_idname = "CompositorNodeFilter"
-    node: bpy.types.CompositorNodeFilter
-
-    def __init__(
-        self,
-        image: InputColor = None,
-        fac: InputFloat = 1.0,
-        type: InputMenu
-        | Literal[
-            "Soften",
-            "Box Sharpen",
-            "Diamond Sharpen",
-            "Laplace",
-            "Sobel",
-            "Prewitt",
-            "Kirsch",
-            "Shadow",
-        ] = "Soften",
-    ):
-        super().__init__()
-        key_args = {"Image": image, "Fac": fac, "Type": type}
-
-        self._establish_links(**key_args)
-
-    @property
-    def i_image(self) -> Socket:
-        """Input socket: Image"""
-        return self.inputs.get("Image")
-
-    @property
-    def i_fac(self) -> Socket:
-        """Input socket: Factor"""
-        return self.inputs.get("Fac")
-
-    @property
-    def i_type(self) -> Socket:
-        """Input socket: Type"""
-        return self.inputs.get("Type")
-
-    @property
-    def o_image(self) -> ColorSocket:
-        """Output socket: Image"""
-        return self.outputs.get("Image")
-
-
 class Glare(NodeBuilder):
     """
     Add lens flares, fog and glows around bright parts of the image

--- a/src/nodebpy/nodes/compositor/filter.py
+++ b/src/nodebpy/nodes/compositor/filter.py
@@ -155,6 +155,142 @@ class Blur(NodeBuilder):
 
         self._establish_links(**key_args)
 
+    @classmethod
+    def flat(
+        cls,
+        image: InputColor = None,
+        size: InputVector = None,
+        extend_bounds: InputBoolean = False,
+        separable: InputBoolean = True,
+    ) -> "Blur":
+        """Create Blur node with type 'Flat'."""
+        return cls(
+            image=image,
+            size=size,
+            extend_bounds=extend_bounds,
+            separable=separable,
+            type="Flat",
+        )
+
+    @classmethod
+    def tent(
+        cls,
+        image: InputColor = None,
+        size: InputVector = None,
+        extend_bounds: InputBoolean = False,
+        separable: InputBoolean = True,
+    ) -> "Blur":
+        """Create Blur node with type 'Tent'."""
+        return cls(
+            image=image,
+            size=size,
+            extend_bounds=extend_bounds,
+            separable=separable,
+            type="Tent",
+        )
+
+    @classmethod
+    def quadratic(
+        cls,
+        image: InputColor = None,
+        size: InputVector = None,
+        extend_bounds: InputBoolean = False,
+        separable: InputBoolean = True,
+    ) -> "Blur":
+        """Create Blur node with type 'Quadratic'."""
+        return cls(
+            image=image,
+            size=size,
+            extend_bounds=extend_bounds,
+            separable=separable,
+            type="Quadratic",
+        )
+
+    @classmethod
+    def cubic(
+        cls,
+        image: InputColor = None,
+        size: InputVector = None,
+        extend_bounds: InputBoolean = False,
+        separable: InputBoolean = True,
+    ) -> "Blur":
+        """Create Blur node with type 'Cubic'."""
+        return cls(
+            image=image,
+            size=size,
+            extend_bounds=extend_bounds,
+            separable=separable,
+            type="Cubic",
+        )
+
+    @classmethod
+    def gaussian(
+        cls,
+        image: InputColor = None,
+        size: InputVector = None,
+        extend_bounds: InputBoolean = False,
+        separable: InputBoolean = True,
+    ) -> "Blur":
+        """Create Blur node with type 'Gaussian'."""
+        return cls(
+            image=image,
+            size=size,
+            extend_bounds=extend_bounds,
+            separable=separable,
+            type="Gaussian",
+        )
+
+    @classmethod
+    def fast_gaussian(
+        cls,
+        image: InputColor = None,
+        size: InputVector = None,
+        extend_bounds: InputBoolean = False,
+        separable: InputBoolean = True,
+    ) -> "Blur":
+        """Create Blur node with type 'Fast Gaussian'."""
+        return cls(
+            image=image,
+            size=size,
+            extend_bounds=extend_bounds,
+            separable=separable,
+            type="Fast Gaussian",
+        )
+
+    @classmethod
+    def catrom(
+        cls,
+        image: InputColor = None,
+        size: InputVector = None,
+        extend_bounds: InputBoolean = False,
+        separable: InputBoolean = True,
+    ) -> "Blur":
+        """Create Blur node with type 'Catrom'."""
+        return cls(
+            image=image,
+            size=size,
+            extend_bounds=extend_bounds,
+            separable=separable,
+            type="Catrom",
+        )
+
+    @classmethod
+    def mitch(
+        cls,
+        image: InputColor = None,
+        size: InputVector = None,
+        extend_bounds: InputBoolean = False,
+        separable: InputBoolean = True,
+    ) -> "Blur":
+        """Create Blur node with type 'Mitch'."""
+        return cls(
+            image=image,
+            size=size,
+            extend_bounds=extend_bounds,
+            separable=separable,
+            type="Mitch",
+        )
+
     @property
     def i_image(self) -> Socket:
         """Input socket: Image"""
@@ -555,6 +691,39 @@ class Dilateerode(NodeBuilder):
 
         self._establish_links(**key_args)
 
+    @classmethod
+    def steps(cls, mask: InputFloat = 0.0, size: InputInteger = 0) -> "Dilateerode":
+        """Create Dilate/Erode node with type 'Steps'."""
+        return cls(mask=mask, size=size, type="Steps")
+
+    @classmethod
+    def threshold(
+        cls,
+        mask: InputFloat = 0.0,
+        size: InputInteger = 0,
+        falloff_size: InputFloat = 0.0,
+    ) -> "Dilateerode":
+        """Create Dilate/Erode node with type 'Threshold'."""
+        return cls(mask=mask, size=size, falloff_size=falloff_size, type="Threshold")
+
+    @classmethod
+    def distance(cls, mask: InputFloat = 0.0, size: InputInteger = 0) -> "Dilateerode":
+        """Create Dilate/Erode node with type 'Distance'."""
+        return cls(mask=mask, size=size, type="Distance")
+
+    @classmethod
+    def feather(
+        cls,
+        mask: InputFloat = 0.0,
+        size: InputInteger = 0,
+        falloff: InputMenu
+        | Literal[
+            "Smooth", "Sphere", "Root", "Inverse Square", "Sharp", "Linear"
+        ] = "Smooth",
+    ) -> "Dilateerode":
+        """Create Dilate/Erode node with type 'Feather'."""
+        return cls(mask=mask, size=size, falloff=falloff, type="Feather")
+
     @property
     def i_mask(self) -> Socket:
         """Input socket: Mask"""
@@ -658,6 +827,98 @@ class DirectionalBlur(NodeBuilder):
         return self.outputs.get("Image")
 
 
+class Filter(NodeBuilder):
+    """
+    Apply common image enhancement filters
+    """
+
+    _bl_idname = "CompositorNodeFilter"
+    node: bpy.types.CompositorNodeFilter
+
+    def __init__(
+        self,
+        image: InputColor = None,
+        fac: InputFloat = 1.0,
+        type: InputMenu
+        | Literal[
+            "Soften",
+            "Box Sharpen",
+            "Diamond Sharpen",
+            "Laplace",
+            "Sobel",
+            "Prewitt",
+            "Kirsch",
+            "Shadow",
+        ] = "Soften",
+    ):
+        super().__init__()
+        key_args = {"Image": image, "Fac": fac, "Type": type}
+
+        self._establish_links(**key_args)
+
+    @classmethod
+    def soften(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        """Create Filter node with type 'Soften'."""
+        return cls(image=image, fac=fac, type="Soften")
+
+    @classmethod
+    def box_sharpen(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        """Create Filter node with type 'Box Sharpen'."""
+        return cls(image=image, fac=fac, type="Box Sharpen")
+
+    @classmethod
+    def diamond_sharpen(
+        cls, image: InputColor = None, fac: InputFloat = 1.0
+    ) -> "Filter":
+        """Create Filter node with type 'Diamond Sharpen'."""
+        return cls(image=image, fac=fac, type="Diamond Sharpen")
+
+    @classmethod
+    def laplace(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        """Create Filter node with type 'Laplace'."""
+        return cls(image=image, fac=fac, type="Laplace")
+
+    @classmethod
+    def sobel(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        """Create Filter node with type 'Sobel'."""
+        return cls(image=image, fac=fac, type="Sobel")
+
+    @classmethod
+    def prewitt(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        """Create Filter node with type 'Prewitt'."""
+        return cls(image=image, fac=fac, type="Prewitt")
+
+    @classmethod
+    def kirsch(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        """Create Filter node with type 'Kirsch'."""
+        return cls(image=image, fac=fac, type="Kirsch")
+
+    @classmethod
+    def shadow(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        """Create Filter node with type 'Shadow'."""
+        return cls(image=image, fac=fac, type="Shadow")
+
+    @property
+    def i_image(self) -> Socket:
+        """Input socket: Image"""
+        return self.inputs.get("Image")
+
+    @property
+    def i_fac(self) -> Socket:
+        """Input socket: Factor"""
+        return self.inputs.get("Fac")
+
+    @property
+    def i_type(self) -> Socket:
+        """Input socket: Type"""
+        return self.inputs.get("Type")
+
+    @property
+    def o_image(self) -> ColorSocket:
+        """Output socket: Image"""
+        return self.outputs.get("Image")
+
+
 class Glare(NodeBuilder):
     """
     Add lens flares, fog and glows around bright parts of the image
@@ -727,6 +988,229 @@ class Glare(NodeBuilder):
         }
 
         self._establish_links(**key_args)
+
+    @classmethod
+    def bloom(
+        cls,
+        image: InputColor = None,
+        quality: InputMenu | Literal["High", "Medium", "Low"] = "Medium",
+        highlights_threshold: InputFloat = 1.0,
+        highlights_smoothness: InputFloat = 0.1,
+        clamp_highlights: InputBoolean = False,
+        max: InputFloat = 10.0,
+        strength: InputFloat = 1.0,
+        saturation: InputFloat = 1.0,
+        tint: InputColor = None,
+        size: InputFloat = 0.5,
+    ) -> "Glare":
+        """Create Glare node with type 'Bloom'."""
+        return cls(
+            image=image,
+            quality=quality,
+            highlights_threshold=highlights_threshold,
+            highlights_smoothness=highlights_smoothness,
+            clamp_highlights=clamp_highlights,
+            maximum_highlights=max,
+            strength=strength,
+            saturation=saturation,
+            tint=tint,
+            size=size,
+            type="Bloom",
+        )
+
+    @classmethod
+    def ghosts(
+        cls,
+        image: InputColor = None,
+        quality: InputMenu | Literal["High", "Medium", "Low"] = "Medium",
+        highlights_threshold: InputFloat = 1.0,
+        highlights_smoothness: InputFloat = 0.1,
+        clamp_highlights: InputBoolean = False,
+        max: InputFloat = 10.0,
+        strength: InputFloat = 1.0,
+        saturation: InputFloat = 1.0,
+        tint: InputColor = None,
+        iterations: InputInteger = 3,
+        color_modulation: InputFloat = 0.25,
+    ) -> "Glare":
+        """Create Glare node with type 'Ghosts'."""
+        return cls(
+            image=image,
+            quality=quality,
+            highlights_threshold=highlights_threshold,
+            highlights_smoothness=highlights_smoothness,
+            clamp_highlights=clamp_highlights,
+            maximum_highlights=max,
+            strength=strength,
+            saturation=saturation,
+            tint=tint,
+            iterations=iterations,
+            color_modulation=color_modulation,
+            type="Ghosts",
+        )
+
+    @classmethod
+    def streaks(
+        cls,
+        image: InputColor = None,
+        quality: InputMenu | Literal["High", "Medium", "Low"] = "Medium",
+        highlights_threshold: InputFloat = 1.0,
+        highlights_smoothness: InputFloat = 0.1,
+        clamp_highlights: InputBoolean = False,
+        max: InputFloat = 10.0,
+        strength: InputFloat = 1.0,
+        saturation: InputFloat = 1.0,
+        tint: InputColor = None,
+        streaks: InputInteger = 4,
+        streaks_angle: InputFloat = 0.0,
+        iterations: InputInteger = 3,
+        fade: InputFloat = 0.9,
+        color_modulation: InputFloat = 0.25,
+    ) -> "Glare":
+        """Create Glare node with type 'Streaks'."""
+        return cls(
+            image=image,
+            quality=quality,
+            highlights_threshold=highlights_threshold,
+            highlights_smoothness=highlights_smoothness,
+            clamp_highlights=clamp_highlights,
+            maximum_highlights=max,
+            strength=strength,
+            saturation=saturation,
+            tint=tint,
+            streaks=streaks,
+            streaks_angle=streaks_angle,
+            iterations=iterations,
+            fade=fade,
+            color_modulation=color_modulation,
+            type="Streaks",
+        )
+
+    @classmethod
+    def fog_glow(
+        cls,
+        image: InputColor = None,
+        quality: InputMenu | Literal["High", "Medium", "Low"] = "Medium",
+        highlights_threshold: InputFloat = 1.0,
+        highlights_smoothness: InputFloat = 0.1,
+        clamp_highlights: InputBoolean = False,
+        max: InputFloat = 10.0,
+        strength: InputFloat = 1.0,
+        saturation: InputFloat = 1.0,
+        tint: InputColor = None,
+        size: InputFloat = 0.5,
+    ) -> "Glare":
+        """Create Glare node with type 'Fog Glow'."""
+        return cls(
+            image=image,
+            quality=quality,
+            highlights_threshold=highlights_threshold,
+            highlights_smoothness=highlights_smoothness,
+            clamp_highlights=clamp_highlights,
+            maximum_highlights=max,
+            strength=strength,
+            saturation=saturation,
+            tint=tint,
+            size=size,
+            type="Fog Glow",
+        )
+
+    @classmethod
+    def simple_star(
+        cls,
+        image: InputColor = None,
+        quality: InputMenu | Literal["High", "Medium", "Low"] = "Medium",
+        highlights_threshold: InputFloat = 1.0,
+        highlights_smoothness: InputFloat = 0.1,
+        clamp_highlights: InputBoolean = False,
+        max: InputFloat = 10.0,
+        strength: InputFloat = 1.0,
+        saturation: InputFloat = 1.0,
+        tint: InputColor = None,
+        iterations: InputInteger = 3,
+        fade: InputFloat = 0.9,
+        diagonal_star: InputBoolean = True,
+    ) -> "Glare":
+        """Create Glare node with type 'Simple Star'."""
+        return cls(
+            image=image,
+            quality=quality,
+            highlights_threshold=highlights_threshold,
+            highlights_smoothness=highlights_smoothness,
+            clamp_highlights=clamp_highlights,
+            maximum_highlights=max,
+            strength=strength,
+            saturation=saturation,
+            tint=tint,
+            iterations=iterations,
+            fade=fade,
+            diagonal_star=diagonal_star,
+            type="Simple Star",
+        )
+
+    @classmethod
+    def sun_beams(
+        cls,
+        image: InputColor = None,
+        quality: InputMenu | Literal["High", "Medium", "Low"] = "Medium",
+        highlights_threshold: InputFloat = 1.0,
+        highlights_smoothness: InputFloat = 0.1,
+        clamp_highlights: InputBoolean = False,
+        max: InputFloat = 10.0,
+        strength: InputFloat = 1.0,
+        saturation: InputFloat = 1.0,
+        tint: InputColor = None,
+        size: InputFloat = 0.5,
+        sun_position: InputVector = None,
+        jitter: InputFloat = 0.0,
+    ) -> "Glare":
+        """Create Glare node with type 'Sun Beams'."""
+        return cls(
+            image=image,
+            quality=quality,
+            highlights_threshold=highlights_threshold,
+            highlights_smoothness=highlights_smoothness,
+            clamp_highlights=clamp_highlights,
+            maximum_highlights=max,
+            strength=strength,
+            saturation=saturation,
+            tint=tint,
+            size=size,
+            sun_position=sun_position,
+            jitter=jitter,
+            type="Sun Beams",
+        )
+
+    @classmethod
+    def kernel(
+        cls,
+        image: InputColor = None,
+        quality: InputMenu | Literal["High", "Medium", "Low"] = "Medium",
+        highlights_threshold: InputFloat = 1.0,
+        highlights_smoothness: InputFloat = 0.1,
+        clamp_highlights: InputBoolean = False,
+        max: InputFloat = 10.0,
+        strength: InputFloat = 1.0,
+        saturation: InputFloat = 1.0,
+        tint: InputColor = None,
+        kernel_data_type: InputMenu | Literal["Float", "Color"] = "Float",
+        float_kernel: InputFloat = 0.0,
+    ) -> "Glare":
+        """Create Glare node with type 'Kernel'."""
+        return cls(
+            image=image,
+            quality=quality,
+            highlights_threshold=highlights_threshold,
+            highlights_smoothness=highlights_smoothness,
+            clamp_highlights=clamp_highlights,
+            maximum_highlights=max,
+            strength=strength,
+            saturation=saturation,
+            tint=tint,
+            kernel_data_type=kernel_data_type,
+            float_kernel=float_kernel,
+            type="Kernel",
+        )
 
     @property
     def i_image(self) -> Socket:
@@ -918,6 +1402,37 @@ class Kuwahara(NodeBuilder):
         }
 
         self._establish_links(**key_args)
+
+    @classmethod
+    def classic(
+        cls,
+        image: InputColor = None,
+        size: InputFloat = 6.0,
+        high_precision: InputBoolean = False,
+    ) -> "Kuwahara":
+        """Create Kuwahara node with type 'Classic'."""
+        return cls(
+            image=image, size=size, high_precision=high_precision, type="Classic"
+        )
+
+    @classmethod
+    def anisotropic(
+        cls,
+        image: InputColor = None,
+        size: InputFloat = 6.0,
+        uniformity: InputInteger = 4,
+        sharpness: InputFloat = 1.0,
+        eccentricity: InputFloat = 1.0,
+    ) -> "Kuwahara":
+        """Create Kuwahara node with type 'Anisotropic'."""
+        return cls(
+            image=image,
+            size=size,
+            uniformity=uniformity,
+            sharpness=sharpness,
+            eccentricity=eccentricity,
+            type="Anisotropic",
+        )
 
     @property
     def i_image(self) -> Socket:

--- a/src/nodebpy/nodes/compositor/manual.py
+++ b/src/nodebpy/nodes/compositor/manual.py
@@ -1,4 +1,19 @@
+from typing import Literal
+
+from ...builder import TreeBuilder
 from ..geometry.manual import _MenuSwitchBase
+
+
+def tree(
+    name: str = "Compositor Nodes",
+    *,
+    collapse: bool = False,
+    arrange: Literal["sugiyama", "simple"] | None = "sugiyama",
+    fake_user: bool = False,
+) -> TreeBuilder:
+    return TreeBuilder.compositor(
+        name, collapse=collapse, arrange=arrange, fake_user=fake_user
+    )
 
 
 class MenuSwitch(_MenuSwitchBase):

--- a/src/nodebpy/nodes/compositor/manual.py
+++ b/src/nodebpy/nodes/compositor/manual.py
@@ -1,9 +1,6 @@
 from typing import Literal
 
-from bpy.types import CompositorNodeFilter
-
-from ...builder import ColorSocket, NodeBuilder, Socket, TreeBuilder
-from ...types import InputColor, InputFloat, InputMenu
+from ...builder import TreeBuilder
 from ..geometry.manual import _MenuSwitchBase
 
 
@@ -29,87 +26,3 @@ class MenuSwitch(_MenuSwitchBase):
     color = _MenuSwitchBase._typed("RGBA")
     string = _MenuSwitchBase._typed("STRING")
     menu = _MenuSwitchBase._typed("MENU")
-
-
-class Filter(NodeBuilder):
-    """
-    Apply common image enhancement filters
-    """
-
-    _bl_idname = "CompositorNodeFilter"
-    node: CompositorNodeFilter
-
-    def __init__(
-        self,
-        image: InputColor = None,
-        fac: InputFloat = 1.0,
-        type: InputMenu
-        | Literal[
-            "Soften",
-            "Box Sharpen",
-            "Diamond Sharpen",
-            "Laplace",
-            "Sobel",
-            "Prewitt",
-            "Kirsch",
-            "Shadow",
-        ] = "Soften",
-    ):
-        super().__init__()
-        key_args = {"Image": image, "Fac": fac, "Type": type}
-
-        self._establish_links(**key_args)
-
-    @classmethod
-    def soften(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
-        return cls(image=image, fac=fac, type="Soften")
-
-    @classmethod
-    def box_sharpen(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
-        return cls(image=image, fac=fac, type="Box Sharpen")
-
-    @classmethod
-    def diamond_sharpen(
-        cls, image: InputColor = None, fac: InputFloat = 1.0
-    ) -> "Filter":
-        return cls(image=image, fac=fac, type="Diamond Sharpen")
-
-    @classmethod
-    def laplace(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
-        return cls(image=image, fac=fac, type="Laplace")
-
-    @classmethod
-    def sobel(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
-        return cls(image=image, fac=fac, type="Sobel")
-
-    @classmethod
-    def prewitt(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
-        return cls(image=image, fac=fac, type="Prewitt")
-
-    @classmethod
-    def kirsch(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
-        return cls(image=image, fac=fac, type="Kirsch")
-
-    @classmethod
-    def shadow(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
-        return cls(image=image, fac=fac, type="Shadow")
-
-    @property
-    def i_image(self) -> Socket:
-        """Input socket: Image"""
-        return self.inputs.get("Image")
-
-    @property
-    def i_fac(self) -> Socket:
-        """Input socket: Factor"""
-        return self.inputs.get("Fac")
-
-    @property
-    def i_type(self) -> Socket:
-        """Input socket: Type"""
-        return self.inputs.get("Type")
-
-    @property
-    def o_image(self) -> ColorSocket:
-        """Output socket: Image"""
-        return self.outputs.get("Image")

--- a/src/nodebpy/nodes/compositor/manual.py
+++ b/src/nodebpy/nodes/compositor/manual.py
@@ -1,6 +1,9 @@
 from typing import Literal
 
-from ...builder import TreeBuilder
+from bpy.types import CompositorNodeFilter
+
+from ...builder import ColorSocket, NodeBuilder, Socket, TreeBuilder
+from ...types import InputColor, InputFloat, InputMenu
 from ..geometry.manual import _MenuSwitchBase
 
 
@@ -26,3 +29,87 @@ class MenuSwitch(_MenuSwitchBase):
     color = _MenuSwitchBase._typed("RGBA")
     string = _MenuSwitchBase._typed("STRING")
     menu = _MenuSwitchBase._typed("MENU")
+
+
+class Filter(NodeBuilder):
+    """
+    Apply common image enhancement filters
+    """
+
+    _bl_idname = "CompositorNodeFilter"
+    node: CompositorNodeFilter
+
+    def __init__(
+        self,
+        image: InputColor = None,
+        fac: InputFloat = 1.0,
+        type: InputMenu
+        | Literal[
+            "Soften",
+            "Box Sharpen",
+            "Diamond Sharpen",
+            "Laplace",
+            "Sobel",
+            "Prewitt",
+            "Kirsch",
+            "Shadow",
+        ] = "Soften",
+    ):
+        super().__init__()
+        key_args = {"Image": image, "Fac": fac, "Type": type}
+
+        self._establish_links(**key_args)
+
+    @classmethod
+    def soften(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        return cls(image=image, fac=fac, type="Soften")
+
+    @classmethod
+    def box_sharpen(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        return cls(image=image, fac=fac, type="Box Sharpen")
+
+    @classmethod
+    def diamond_sharpen(
+        cls, image: InputColor = None, fac: InputFloat = 1.0
+    ) -> "Filter":
+        return cls(image=image, fac=fac, type="Diamond Sharpen")
+
+    @classmethod
+    def laplace(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        return cls(image=image, fac=fac, type="Laplace")
+
+    @classmethod
+    def sobel(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        return cls(image=image, fac=fac, type="Sobel")
+
+    @classmethod
+    def prewitt(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        return cls(image=image, fac=fac, type="Prewitt")
+
+    @classmethod
+    def kirsch(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        return cls(image=image, fac=fac, type="Kirsch")
+
+    @classmethod
+    def shadow(cls, image: InputColor = None, fac: InputFloat = 1.0) -> "Filter":
+        return cls(image=image, fac=fac, type="Shadow")
+
+    @property
+    def i_image(self) -> Socket:
+        """Input socket: Image"""
+        return self.inputs.get("Image")
+
+    @property
+    def i_fac(self) -> Socket:
+        """Input socket: Factor"""
+        return self.inputs.get("Fac")
+
+    @property
+    def i_type(self) -> Socket:
+        """Input socket: Type"""
+        return self.inputs.get("Type")
+
+    @property
+    def o_image(self) -> ColorSocket:
+        """Output socket: Image"""
+        return self.outputs.get("Image")

--- a/src/nodebpy/nodes/geometry/__init__.py
+++ b/src/nodebpy/nodes/geometry/__init__.py
@@ -34,6 +34,7 @@ from .manual import (
     FieldVariance,
     Compare,
     AttributeStatistic,
+    tree,
 )
 from .converter import (
     AlignRotationToVector,
@@ -654,4 +655,5 @@ __all__ = (
     "Warning",
     "WaveTexture",
     "WhiteNoiseTexture",
+    "tree",
 )

--- a/src/nodebpy/nodes/geometry/attribute.py
+++ b/src/nodebpy/nodes/geometry/attribute.py
@@ -54,7 +54,7 @@ class BlurAttribute(NodeBuilder):
         iterations: InputInteger = 1,
         weight: InputFloat = 1.0,
     ) -> "BlurAttribute":
-        """Create Blur Attribute with operation 'Float'."""
+        """Create Blur Attribute with operation 'Float'. Floating-point value"""
         return cls(data_type="FLOAT", value=value, iterations=iterations, weight=weight)
 
     @classmethod
@@ -64,7 +64,7 @@ class BlurAttribute(NodeBuilder):
         iterations: InputInteger = 1,
         weight: InputFloat = 1.0,
     ) -> "BlurAttribute":
-        """Create Blur Attribute with operation 'Integer'."""
+        """Create Blur Attribute with operation 'Integer'. 32-bit integer"""
         return cls(data_type="INT", value=value, iterations=iterations, weight=weight)
 
     @classmethod
@@ -74,7 +74,7 @@ class BlurAttribute(NodeBuilder):
         iterations: InputInteger = 1,
         weight: InputFloat = 1.0,
     ) -> "BlurAttribute":
-        """Create Blur Attribute with operation 'Vector'."""
+        """Create Blur Attribute with operation 'Vector'. 3D vector with floating-point values"""
         return cls(
             data_type="FLOAT_VECTOR", value=value, iterations=iterations, weight=weight
         )
@@ -86,7 +86,7 @@ class BlurAttribute(NodeBuilder):
         iterations: InputInteger = 1,
         weight: InputFloat = 1.0,
     ) -> "BlurAttribute":
-        """Create Blur Attribute with operation 'Color'."""
+        """Create Blur Attribute with operation 'Color'. RGBA color with 32-bit floating-point values"""
         return cls(
             data_type="FLOAT_COLOR", value=value, iterations=iterations, weight=weight
         )
@@ -284,7 +284,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputFloat = 0.0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Float'."""
+        """Create Store Named Attribute with operation 'Float'. Floating-point value"""
         return cls(
             data_type="FLOAT",
             geometry=geometry,
@@ -301,7 +301,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputInteger = 0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Integer'."""
+        """Create Store Named Attribute with operation 'Integer'. 32-bit integer"""
         return cls(
             data_type="INT",
             geometry=geometry,
@@ -318,7 +318,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputBoolean = False,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Boolean'."""
+        """Create Store Named Attribute with operation 'Boolean'. True or false"""
         return cls(
             data_type="BOOLEAN",
             geometry=geometry,
@@ -335,7 +335,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputVector = None,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Vector'."""
+        """Create Store Named Attribute with operation 'Vector'. 3D vector with floating-point values"""
         return cls(
             data_type="FLOAT_VECTOR",
             geometry=geometry,
@@ -352,7 +352,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputColor = None,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Color'."""
+        """Create Store Named Attribute with operation 'Color'. RGBA color with 32-bit floating-point values"""
         return cls(
             data_type="FLOAT_COLOR",
             geometry=geometry,
@@ -369,7 +369,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputRotation = None,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Quaternion'."""
+        """Create Store Named Attribute with operation 'Quaternion'. Floating point quaternion rotation"""
         return cls(
             data_type="QUATERNION",
             geometry=geometry,
@@ -379,14 +379,14 @@ class StoreNamedAttribute(NodeBuilder):
         )
 
     @classmethod
-    def matrix(
+    def input_4x4_matrix(
         cls,
         geometry: InputGeometry = None,
         selection: InputBoolean = True,
         name: InputString = "",
         value: InputMatrix = None,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation '4x4 Matrix'."""
+        """Create Store Named Attribute with operation '4x4 Matrix'. Floating point matrix"""
         return cls(
             data_type="FLOAT4X4",
             geometry=geometry,
@@ -396,14 +396,14 @@ class StoreNamedAttribute(NodeBuilder):
         )
 
     @classmethod
-    def int8(
+    def input_8_bit_integer(
         cls,
         geometry: InputGeometry = None,
         selection: InputBoolean = True,
         name: InputString = "",
         value: InputInteger = 0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation '8-Bit Integer'."""
+        """Create Store Named Attribute with operation '8-Bit Integer'. Smaller integer with a range from -128 to 127"""
         return cls(
             data_type="INT8",
             geometry=geometry,
@@ -413,14 +413,14 @@ class StoreNamedAttribute(NodeBuilder):
         )
 
     @classmethod
-    def vector2(
+    def input_2d_vector(
         cls,
         geometry: InputGeometry = None,
         selection: InputBoolean = True,
         name: InputString = "",
         value: InputVector = None,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation '2D Vector'."""
+        """Create Store Named Attribute with operation '2D Vector'. 2D vector with floating-point values"""
         return cls(
             data_type="FLOAT2",
             geometry=geometry,
@@ -437,7 +437,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputColor = None,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Byte Color'."""
+        """Create Store Named Attribute with operation 'Byte Color'. RGBA color with 8-bit positive integer values"""
         return cls(
             data_type="BYTE_COLOR",
             geometry=geometry,
@@ -454,7 +454,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputFloat = 0.0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Point'."""
+        """Create Store Named Attribute with operation 'Point'. Attribute on point"""
         return cls(
             domain="POINT",
             geometry=geometry,
@@ -471,7 +471,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputFloat = 0.0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Edge'."""
+        """Create Store Named Attribute with operation 'Edge'. Attribute on mesh edge"""
         return cls(
             domain="EDGE",
             geometry=geometry,
@@ -488,7 +488,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputFloat = 0.0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Face'."""
+        """Create Store Named Attribute with operation 'Face'. Attribute on mesh faces"""
         return cls(
             domain="FACE",
             geometry=geometry,
@@ -505,7 +505,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputFloat = 0.0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Face Corner'."""
+        """Create Store Named Attribute with operation 'Face Corner'. Attribute on mesh face corner"""
         return cls(
             domain="CORNER",
             geometry=geometry,
@@ -522,7 +522,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputFloat = 0.0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Spline'."""
+        """Create Store Named Attribute with operation 'Spline'. Attribute on spline"""
         return cls(
             domain="CURVE",
             geometry=geometry,
@@ -539,7 +539,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputFloat = 0.0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Instance'."""
+        """Create Store Named Attribute with operation 'Instance'. Attribute on instance"""
         return cls(
             domain="INSTANCE",
             geometry=geometry,
@@ -556,7 +556,7 @@ class StoreNamedAttribute(NodeBuilder):
         name: InputString = "",
         value: InputFloat = 0.0,
     ) -> "StoreNamedAttribute":
-        """Create Store Named Attribute with operation 'Layer'."""
+        """Create Store Named Attribute with operation 'Layer'. Attribute on Grease Pencil layer"""
         return cls(
             domain="LAYER",
             geometry=geometry,

--- a/src/nodebpy/nodes/geometry/converter.py
+++ b/src/nodebpy/nodes/geometry/converter.py
@@ -210,32 +210,32 @@ class BitMath(NodeBuilder):
 
     @classmethod
     def l_and(cls, a: InputInteger = 0, b: InputInteger = 0) -> "BitMath":
-        """Create Bit Math with operation 'And'."""
+        """Create Bit Math with operation 'And'. Returns a value where the bits of A and B are both set"""
         return cls(operation="AND", a=a, b=b)
 
     @classmethod
     def l_or(cls, a: InputInteger = 0, b: InputInteger = 0) -> "BitMath":
-        """Create Bit Math with operation 'Or'."""
+        """Create Bit Math with operation 'Or'. Returns a value where the bits of either A or B are set"""
         return cls(operation="OR", a=a, b=b)
 
     @classmethod
     def exclusive_or(cls, a: InputInteger = 0, b: InputInteger = 0) -> "BitMath":
-        """Create Bit Math with operation 'Exclusive Or'."""
+        """Create Bit Math with operation 'Exclusive Or'. Returns a value where only one bit from A and B is set"""
         return cls(operation="XOR", a=a, b=b)
 
     @classmethod
     def l_not(cls, a: InputInteger = 0) -> "BitMath":
-        """Create Bit Math with operation 'Not'."""
+        """Create Bit Math with operation 'Not'. Returns the opposite bit value of A, in decimal it is equivalent of A = -A - 1"""
         return cls(operation="NOT", a=a)
 
     @classmethod
     def shift(cls, a: InputInteger = 0, shift: InputInteger = 0) -> "BitMath":
-        """Create Bit Math with operation 'Shift'."""
+        """Create Bit Math with operation 'Shift'. Shifts the bit values of A by the specified Shift amount. Positive values shift left, negative values shift right."""
         return cls(operation="SHIFT", a=a, shift=shift)
 
     @classmethod
     def rotate(cls, a: InputInteger = 0, shift: InputInteger = 0) -> "BitMath":
-        """Create Bit Math with operation 'Rotate'."""
+        """Create Bit Math with operation 'Rotate'. Rotates the bit values of A by the specified Shift amount. Positive values rotate left, negative values rotate right."""
         return cls(operation="ROTATE", a=a, shift=shift)
 
     @property
@@ -318,61 +318,61 @@ class BooleanMath(NodeBuilder):
     def l_and(
         cls, boolean: InputBoolean = False, boolean_001: InputBoolean = False
     ) -> "BooleanMath":
-        """Create Boolean Math with operation 'And'."""
+        """Create Boolean Math with operation 'And'. True when both inputs are true"""
         return cls(operation="AND", boolean=boolean, boolean_001=boolean_001)
 
     @classmethod
     def l_or(
         cls, boolean: InputBoolean = False, boolean_001: InputBoolean = False
     ) -> "BooleanMath":
-        """Create Boolean Math with operation 'Or'."""
+        """Create Boolean Math with operation 'Or'. True when at least one input is true"""
         return cls(operation="OR", boolean=boolean, boolean_001=boolean_001)
 
     @classmethod
     def l_not(cls, boolean: InputBoolean = False) -> "BooleanMath":
-        """Create Boolean Math with operation 'Not'."""
+        """Create Boolean Math with operation 'Not'. Opposite of the input"""
         return cls(operation="NOT", boolean=boolean)
 
     @classmethod
     def not_and(
         cls, boolean: InputBoolean = False, boolean_001: InputBoolean = False
     ) -> "BooleanMath":
-        """Create Boolean Math with operation 'Not And'."""
+        """Create Boolean Math with operation 'Not And'. True when at least one input is false"""
         return cls(operation="NAND", boolean=boolean, boolean_001=boolean_001)
 
     @classmethod
     def nor(
         cls, boolean: InputBoolean = False, boolean_001: InputBoolean = False
     ) -> "BooleanMath":
-        """Create Boolean Math with operation 'Nor'."""
+        """Create Boolean Math with operation 'Nor'. True when both inputs are false"""
         return cls(operation="NOR", boolean=boolean, boolean_001=boolean_001)
 
     @classmethod
     def equal(
         cls, boolean: InputBoolean = False, boolean_001: InputBoolean = False
     ) -> "BooleanMath":
-        """Create Boolean Math with operation 'Equal'."""
+        """Create Boolean Math with operation 'Equal'. True when both inputs are equal (exclusive nor)"""
         return cls(operation="XNOR", boolean=boolean, boolean_001=boolean_001)
 
     @classmethod
     def not_equal(
         cls, boolean: InputBoolean = False, boolean_001: InputBoolean = False
     ) -> "BooleanMath":
-        """Create Boolean Math with operation 'Not Equal'."""
+        """Create Boolean Math with operation 'Not Equal'. True when both inputs are different (exclusive or)"""
         return cls(operation="XOR", boolean=boolean, boolean_001=boolean_001)
 
     @classmethod
     def imply(
         cls, boolean: InputBoolean = False, boolean_001: InputBoolean = False
     ) -> "BooleanMath":
-        """Create Boolean Math with operation 'Imply'."""
+        """Create Boolean Math with operation 'Imply'. True unless the first input is true and the second is false"""
         return cls(operation="IMPLY", boolean=boolean, boolean_001=boolean_001)
 
     @classmethod
     def subtract(
         cls, boolean: InputBoolean = False, boolean_001: InputBoolean = False
     ) -> "BooleanMath":
-        """Create Boolean Math with operation 'Subtract'."""
+        """Create Boolean Math with operation 'Subtract'. True when the first input is true and the second is false (not imply)"""
         return cls(operation="NIMPLY", boolean=boolean, boolean_001=boolean_001)
 
     @property
@@ -1092,28 +1092,28 @@ class IntegerMath(NodeBuilder):
 
     @classmethod
     def add(cls, value: InputInteger = 0, value_001: InputInteger = 0) -> "IntegerMath":
-        """Create Integer Math with operation 'Add'."""
+        """Create Integer Math with operation 'Add'. A + B"""
         return cls(operation="ADD", value=value, value_001=value_001)
 
     @classmethod
     def subtract(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Subtract'."""
+        """Create Integer Math with operation 'Subtract'. A - B"""
         return cls(operation="SUBTRACT", value=value, value_001=value_001)
 
     @classmethod
     def multiply(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Multiply'."""
+        """Create Integer Math with operation 'Multiply'. A * B"""
         return cls(operation="MULTIPLY", value=value, value_001=value_001)
 
     @classmethod
     def divide(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Divide'."""
+        """Create Integer Math with operation 'Divide'. A / B"""
         return cls(operation="DIVIDE", value=value, value_001=value_001)
 
     @classmethod
@@ -1123,7 +1123,7 @@ class IntegerMath(NodeBuilder):
         value_001: InputInteger = 0,
         value_002: InputInteger = 0,
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Multiply Add'."""
+        """Create Integer Math with operation 'Multiply Add'. A * B + C"""
         return cls(
             operation="MULTIPLY_ADD",
             value=value,
@@ -1133,87 +1133,87 @@ class IntegerMath(NodeBuilder):
 
     @classmethod
     def absolute(cls, value: InputInteger = 0) -> "IntegerMath":
-        """Create Integer Math with operation 'Absolute'."""
+        """Create Integer Math with operation 'Absolute'. Non-negative value of A, abs(A)"""
         return cls(operation="ABSOLUTE", value=value)
 
     @classmethod
     def negate(cls, value: InputInteger = 0) -> "IntegerMath":
-        """Create Integer Math with operation 'Negate'."""
+        """Create Integer Math with operation 'Negate'. -A"""
         return cls(operation="NEGATE", value=value)
 
     @classmethod
     def power(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Power'."""
+        """Create Integer Math with operation 'Power'. A power B, pow(A,B)"""
         return cls(operation="POWER", value=value, value_001=value_001)
 
     @classmethod
     def minimum(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Minimum'."""
+        """Create Integer Math with operation 'Minimum'. The minimum value from A and B, min(A,B)"""
         return cls(operation="MINIMUM", value=value, value_001=value_001)
 
     @classmethod
     def maximum(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Maximum'."""
+        """Create Integer Math with operation 'Maximum'. The maximum value from A and B, max(A,B)"""
         return cls(operation="MAXIMUM", value=value, value_001=value_001)
 
     @classmethod
     def sign(cls, value: InputInteger = 0) -> "IntegerMath":
-        """Create Integer Math with operation 'Sign'."""
+        """Create Integer Math with operation 'Sign'. Return the sign of A, sign(A)"""
         return cls(operation="SIGN", value=value)
 
     @classmethod
     def divide_round(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Divide Round'."""
+        """Create Integer Math with operation 'Divide Round'. Divide and round result toward zero"""
         return cls(operation="DIVIDE_ROUND", value=value, value_001=value_001)
 
     @classmethod
     def divide_floor(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Divide Floor'."""
+        """Create Integer Math with operation 'Divide Floor'. Divide and floor result, the largest integer smaller than or equal A"""
         return cls(operation="DIVIDE_FLOOR", value=value, value_001=value_001)
 
     @classmethod
     def divide_ceiling(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Divide Ceiling'."""
+        """Create Integer Math with operation 'Divide Ceiling'. Divide and ceil result, the smallest integer greater than or equal A"""
         return cls(operation="DIVIDE_CEIL", value=value, value_001=value_001)
 
     @classmethod
     def floored_modulo(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Floored Modulo'."""
+        """Create Integer Math with operation 'Floored Modulo'. Modulo that is periodic for both negative and positive operands"""
         return cls(operation="FLOORED_MODULO", value=value, value_001=value_001)
 
     @classmethod
     def modulo(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Modulo'."""
+        """Create Integer Math with operation 'Modulo'. Modulo which is the remainder of A / B"""
         return cls(operation="MODULO", value=value, value_001=value_001)
 
     @classmethod
     def greatest_common_divisor(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Greatest Common Divisor'."""
+        """Create Integer Math with operation 'Greatest Common Divisor'. The largest positive integer that divides into each of the values A and B, e.g. GCD(8,12) = 4"""
         return cls(operation="GCD", value=value, value_001=value_001)
 
     @classmethod
     def least_common_multiple(
         cls, value: InputInteger = 0, value_001: InputInteger = 0
     ) -> "IntegerMath":
-        """Create Integer Math with operation 'Least Common Multiple'."""
+        """Create Integer Math with operation 'Least Common Multiple'. The smallest positive integer that is divisible by both A and B, e.g. LCM(6,10) = 30"""
         return cls(operation="LCM", value=value, value_001=value_001)
 
     @property
@@ -1426,7 +1426,7 @@ class MapRange(NodeBuilder):
         to_min: InputFloat = 0.0,
         to_max: InputFloat = 1.0,
     ) -> "MapRange":
-        """Create Map Range with operation 'Float'."""
+        """Create Map Range with operation 'Float'. Floating-point value"""
         return cls(
             data_type="FLOAT",
             value=value,
@@ -1445,7 +1445,7 @@ class MapRange(NodeBuilder):
         to_min3: InputVector = None,
         to_max3: InputVector = None,
     ) -> "MapRange":
-        """Create Map Range with operation 'Vector'."""
+        """Create Map Range with operation 'Vector'. 3D vector with floating-point values"""
         return cls(
             data_type="FLOAT_VECTOR",
             vector=vector,
@@ -1662,22 +1662,22 @@ class Math(NodeBuilder):
 
     @classmethod
     def add(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Add'."""
+        """Create Math with operation 'Add'. A + B"""
         return cls(operation="ADD", value=value, value_001=value_001)
 
     @classmethod
     def subtract(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Subtract'."""
+        """Create Math with operation 'Subtract'. A - B"""
         return cls(operation="SUBTRACT", value=value, value_001=value_001)
 
     @classmethod
     def multiply(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Multiply'."""
+        """Create Math with operation 'Multiply'. A * B"""
         return cls(operation="MULTIPLY", value=value, value_001=value_001)
 
     @classmethod
     def divide(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Divide'."""
+        """Create Math with operation 'Divide'. A / B"""
         return cls(operation="DIVIDE", value=value, value_001=value_001)
 
     @classmethod
@@ -1687,7 +1687,7 @@ class Math(NodeBuilder):
         value_001: InputFloat = 0.5,
         value_002: InputFloat = 0.5,
     ) -> "Math":
-        """Create Math with operation 'Multiply Add'."""
+        """Create Math with operation 'Multiply Add'. A * B + C"""
         return cls(
             operation="MULTIPLY_ADD",
             value=value,
@@ -1697,59 +1697,59 @@ class Math(NodeBuilder):
 
     @classmethod
     def power(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Power'."""
+        """Create Math with operation 'Power'. A power B"""
         return cls(operation="POWER", value=value, value_001=value_001)
 
     @classmethod
     def logarithm(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Logarithm'."""
+        """Create Math with operation 'Logarithm'. Logarithm A base B"""
         return cls(operation="LOGARITHM", value=value, value_001=value_001)
 
     @classmethod
     def square_root(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Square Root'."""
+        """Create Math with operation 'Square Root'. Square root of A"""
         return cls(operation="SQRT", value=value)
 
     @classmethod
     def inverse_square_root(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Inverse Square Root'."""
+        """Create Math with operation 'Inverse Square Root'. 1 / Square root of A"""
         return cls(operation="INVERSE_SQRT", value=value)
 
     @classmethod
     def absolute(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Absolute'."""
+        """Create Math with operation 'Absolute'. Magnitude of A"""
         return cls(operation="ABSOLUTE", value=value)
 
     @classmethod
     def exponent(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Exponent'."""
+        """Create Math with operation 'Exponent'. exp(A)"""
         return cls(operation="EXPONENT", value=value)
 
     @classmethod
     def minimum(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Minimum'."""
+        """Create Math with operation 'Minimum'. The minimum from A and B"""
         return cls(operation="MINIMUM", value=value, value_001=value_001)
 
     @classmethod
     def maximum(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Maximum'."""
+        """Create Math with operation 'Maximum'. The maximum from A and B"""
         return cls(operation="MAXIMUM", value=value, value_001=value_001)
 
     @classmethod
     def less_than(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Less Than'."""
+        """Create Math with operation 'Less Than'. 1 if A < B else 0"""
         return cls(operation="LESS_THAN", value=value, value_001=value_001)
 
     @classmethod
     def greater_than(
         cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5
     ) -> "Math":
-        """Create Math with operation 'Greater Than'."""
+        """Create Math with operation 'Greater Than'. 1 if A > B else 0"""
         return cls(operation="GREATER_THAN", value=value, value_001=value_001)
 
     @classmethod
     def sign(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Sign'."""
+        """Create Math with operation 'Sign'. Returns the sign of A"""
         return cls(operation="SIGN", value=value)
 
     @classmethod
@@ -1759,7 +1759,7 @@ class Math(NodeBuilder):
         value_001: InputFloat = 0.5,
         value_002: InputFloat = 0.5,
     ) -> "Math":
-        """Create Math with operation 'Compare'."""
+        """Create Math with operation 'Compare'. 1 if (A == B) within tolerance C else 0"""
         return cls(
             operation="COMPARE", value=value, value_001=value_001, value_002=value_002
         )
@@ -1771,7 +1771,7 @@ class Math(NodeBuilder):
         value_001: InputFloat = 0.5,
         value_002: InputFloat = 0.5,
     ) -> "Math":
-        """Create Math with operation 'Smooth Minimum'."""
+        """Create Math with operation 'Smooth Minimum'. The minimum from A and B with smoothing C"""
         return cls(
             operation="SMOOTH_MIN",
             value=value,
@@ -1786,7 +1786,7 @@ class Math(NodeBuilder):
         value_001: InputFloat = 0.5,
         value_002: InputFloat = 0.5,
     ) -> "Math":
-        """Create Math with operation 'Smooth Maximum'."""
+        """Create Math with operation 'Smooth Maximum'. The maximum from A and B with smoothing C"""
         return cls(
             operation="SMOOTH_MAX",
             value=value,
@@ -1796,41 +1796,41 @@ class Math(NodeBuilder):
 
     @classmethod
     def round(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Round'."""
+        """Create Math with operation 'Round'. Round A to the nearest integer. Round upward if the fraction part is 0.5"""
         return cls(operation="ROUND", value=value)
 
     @classmethod
     def floor(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Floor'."""
+        """Create Math with operation 'Floor'. The largest integer smaller than or equal A"""
         return cls(operation="FLOOR", value=value)
 
     @classmethod
     def ceil(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Ceil'."""
+        """Create Math with operation 'Ceil'. The smallest integer greater than or equal A"""
         return cls(operation="CEIL", value=value)
 
     @classmethod
     def truncate(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Truncate'."""
+        """Create Math with operation 'Truncate'. The integer part of A, removing fractional digits"""
         return cls(operation="TRUNC", value=value)
 
     @classmethod
     def fraction(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Fraction'."""
+        """Create Math with operation 'Fraction'. The fraction part of A"""
         return cls(operation="FRACT", value=value)
 
     @classmethod
     def truncated_modulo(
         cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5
     ) -> "Math":
-        """Create Math with operation 'Truncated Modulo'."""
+        """Create Math with operation 'Truncated Modulo'. The remainder of truncated division using fmod(A,B)"""
         return cls(operation="MODULO", value=value, value_001=value_001)
 
     @classmethod
     def floored_modulo(
         cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5
     ) -> "Math":
-        """Create Math with operation 'Floored Modulo'."""
+        """Create Math with operation 'Floored Modulo'. The remainder of floored division"""
         return cls(operation="FLOORED_MODULO", value=value, value_001=value_001)
 
     @classmethod
@@ -1840,79 +1840,79 @@ class Math(NodeBuilder):
         value_001: InputFloat = 0.5,
         value_002: InputFloat = 0.5,
     ) -> "Math":
-        """Create Math with operation 'Wrap'."""
+        """Create Math with operation 'Wrap'. Wrap value to range, wrap(A,B)"""
         return cls(
             operation="WRAP", value=value, value_001=value_001, value_002=value_002
         )
 
     @classmethod
     def snap(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Snap'."""
+        """Create Math with operation 'Snap'. Snap to increment, snap(A,B)"""
         return cls(operation="SNAP", value=value, value_001=value_001)
 
     @classmethod
     def ping_pong(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Ping-Pong'."""
+        """Create Math with operation 'Ping-Pong'. Wraps a value and reverses every other cycle (A,B)"""
         return cls(operation="PINGPONG", value=value, value_001=value_001)
 
     @classmethod
     def sine(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Sine'."""
+        """Create Math with operation 'Sine'. sin(A)"""
         return cls(operation="SINE", value=value)
 
     @classmethod
     def cosine(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Cosine'."""
+        """Create Math with operation 'Cosine'. cos(A)"""
         return cls(operation="COSINE", value=value)
 
     @classmethod
     def tangent(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Tangent'."""
+        """Create Math with operation 'Tangent'. tan(A)"""
         return cls(operation="TANGENT", value=value)
 
     @classmethod
     def arcsine(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Arcsine'."""
+        """Create Math with operation 'Arcsine'. arcsin(A)"""
         return cls(operation="ARCSINE", value=value)
 
     @classmethod
     def arccosine(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Arccosine'."""
+        """Create Math with operation 'Arccosine'. arccos(A)"""
         return cls(operation="ARCCOSINE", value=value)
 
     @classmethod
     def arctangent(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Arctangent'."""
+        """Create Math with operation 'Arctangent'. arctan(A)"""
         return cls(operation="ARCTANGENT", value=value)
 
     @classmethod
     def arctan2(cls, value: InputFloat = 0.5, value_001: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Arctan2'."""
+        """Create Math with operation 'Arctan2'. The signed angle arctan(A / B)"""
         return cls(operation="ARCTAN2", value=value, value_001=value_001)
 
     @classmethod
     def hyperbolic_sine(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Hyperbolic Sine'."""
+        """Create Math with operation 'Hyperbolic Sine'. sinh(A)"""
         return cls(operation="SINH", value=value)
 
     @classmethod
     def hyperbolic_cosine(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Hyperbolic Cosine'."""
+        """Create Math with operation 'Hyperbolic Cosine'. cosh(A)"""
         return cls(operation="COSH", value=value)
 
     @classmethod
     def hyperbolic_tangent(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'Hyperbolic Tangent'."""
+        """Create Math with operation 'Hyperbolic Tangent'. tanh(A)"""
         return cls(operation="TANH", value=value)
 
     @classmethod
     def to_radians(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'To Radians'."""
+        """Create Math with operation 'To Radians'. Convert from degrees to radians"""
         return cls(operation="RADIANS", value=value)
 
     @classmethod
     def to_degrees(cls, value: InputFloat = 0.5) -> "Math":
-        """Create Math with operation 'To Degrees'."""
+        """Create Math with operation 'To Degrees'. Convert from radians to degrees"""
         return cls(operation="DEGREES", value=value)
 
     @property
@@ -2548,7 +2548,7 @@ class RandomValue(NodeBuilder):
         id: InputInteger = 0,
         seed: InputInteger = 0,
     ) -> "RandomValue":
-        """Create Random Value with operation 'Float'."""
+        """Create Random Value with operation 'Float'. Floating-point value"""
         return cls(data_type="FLOAT", min_001=min, max_001=max, id=id, seed=seed)
 
     @classmethod
@@ -2559,14 +2559,14 @@ class RandomValue(NodeBuilder):
         id: InputInteger = 0,
         seed: InputInteger = 0,
     ) -> "RandomValue":
-        """Create Random Value with operation 'Integer'."""
+        """Create Random Value with operation 'Integer'. 32-bit integer"""
         return cls(data_type="INT", min_002=min, max_002=max, id=id, seed=seed)
 
     @classmethod
     def boolean(
         cls, probability: InputFloat = 0.5, id: InputInteger = 0, seed: InputInteger = 0
     ) -> "RandomValue":
-        """Create Random Value with operation 'Boolean'."""
+        """Create Random Value with operation 'Boolean'. True or false"""
         return cls(data_type="BOOLEAN", probability=probability, id=id, seed=seed)
 
     @classmethod
@@ -2577,7 +2577,7 @@ class RandomValue(NodeBuilder):
         id: InputInteger = 0,
         seed: InputInteger = 0,
     ) -> "RandomValue":
-        """Create Random Value with operation 'Vector'."""
+        """Create Random Value with operation 'Vector'. 3D vector with floating-point values"""
         return cls(data_type="FLOAT_VECTOR", min=min, max=max, id=id, seed=seed)
 
     @property
@@ -3280,12 +3280,12 @@ class StringToValue(NodeBuilder):
 
     @classmethod
     def float(cls, string: InputString = "") -> "StringToValue":
-        """Create String to Value with operation 'Float'."""
+        """Create String to Value with operation 'Float'. Floating-point value"""
         return cls(data_type="FLOAT", string=string)
 
     @classmethod
     def integer(cls, string: InputString = "") -> "StringToValue":
-        """Create String to Value with operation 'Integer'."""
+        """Create String to Value with operation 'Integer'. 32-bit integer"""
         return cls(data_type="INT", string=string)
 
     @property
@@ -3753,12 +3753,12 @@ class ValueToString(NodeBuilder):
     def float(
         cls, value: InputFloat = 0.0, decimals: InputInteger = 0
     ) -> "ValueToString":
-        """Create Value to String with operation 'Float'."""
+        """Create Value to String with operation 'Float'. Floating-point value"""
         return cls(data_type="FLOAT", value=value, decimals=decimals)
 
     @classmethod
     def integer(cls, value: InputInteger = 0) -> "ValueToString":
-        """Create Value to String with operation 'Integer'."""
+        """Create Value to String with operation 'Integer'. 32-bit integer"""
         return cls(data_type="INT", value=value)
 
     @property

--- a/src/nodebpy/nodes/geometry/geometry.py
+++ b/src/nodebpy/nodes/geometry/geometry.py
@@ -897,42 +897,42 @@ class DeleteGeometry(NodeBuilder):
     def point(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "DeleteGeometry":
-        """Create Delete Geometry with operation 'Point'."""
+        """Create Delete Geometry with operation 'Point'. Attribute on point"""
         return cls(domain="POINT", geometry=geometry, selection=selection)
 
     @classmethod
     def edge(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "DeleteGeometry":
-        """Create Delete Geometry with operation 'Edge'."""
+        """Create Delete Geometry with operation 'Edge'. Attribute on mesh edge"""
         return cls(domain="EDGE", geometry=geometry, selection=selection)
 
     @classmethod
     def face(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "DeleteGeometry":
-        """Create Delete Geometry with operation 'Face'."""
+        """Create Delete Geometry with operation 'Face'. Attribute on mesh faces"""
         return cls(domain="FACE", geometry=geometry, selection=selection)
 
     @classmethod
     def spline(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "DeleteGeometry":
-        """Create Delete Geometry with operation 'Spline'."""
+        """Create Delete Geometry with operation 'Spline'. Attribute on spline"""
         return cls(domain="CURVE", geometry=geometry, selection=selection)
 
     @classmethod
     def instance(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "DeleteGeometry":
-        """Create Delete Geometry with operation 'Instance'."""
+        """Create Delete Geometry with operation 'Instance'. Attribute on instance"""
         return cls(domain="INSTANCE", geometry=geometry, selection=selection)
 
     @classmethod
     def layer(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "DeleteGeometry":
-        """Create Delete Geometry with operation 'Layer'."""
+        """Create Delete Geometry with operation 'Layer'. Attribute on Grease Pencil layer"""
         return cls(domain="LAYER", geometry=geometry, selection=selection)
 
     @property
@@ -2063,19 +2063,19 @@ class MeshBoolean(NodeBuilder):
 
     @classmethod
     def intersect(cls, mesh_2: InputGeometry = None) -> "MeshBoolean":
-        """Create Mesh Boolean with operation 'Intersect'."""
+        """Create Mesh Boolean with operation 'Intersect'. Keep the part of the mesh that is common between all operands"""
         return cls(operation="INTERSECT", mesh_2=mesh_2)
 
     @classmethod
     def union(cls, mesh_2: InputGeometry = None) -> "MeshBoolean":
-        """Create Mesh Boolean with operation 'Union'."""
+        """Create Mesh Boolean with operation 'Union'. Combine meshes in an additive way"""
         return cls(operation="UNION", mesh_2=mesh_2)
 
     @classmethod
     def difference(
         cls, mesh_1: InputGeometry = None, mesh_2: InputGeometry = None
     ) -> "MeshBoolean":
-        """Create Mesh Boolean with operation 'Difference'."""
+        """Create Mesh Boolean with operation 'Difference'. Combine meshes in a subtractive way"""
         return cls(operation="DIFFERENCE", mesh_1=mesh_1, mesh_2=mesh_2)
 
     @property
@@ -2680,7 +2680,7 @@ class Raycast(NodeBuilder):
         ray_direction: InputVector = None,
         ray_length: InputFloat = 100.0,
     ) -> "Raycast":
-        """Create Raycast with operation 'Float'."""
+        """Create Raycast with operation 'Float'. Floating-point value"""
         return cls(
             data_type="FLOAT",
             target_geometry=target_geometry,
@@ -2701,7 +2701,7 @@ class Raycast(NodeBuilder):
         ray_direction: InputVector = None,
         ray_length: InputFloat = 100.0,
     ) -> "Raycast":
-        """Create Raycast with operation 'Integer'."""
+        """Create Raycast with operation 'Integer'. 32-bit integer"""
         return cls(
             data_type="INT",
             target_geometry=target_geometry,
@@ -2722,7 +2722,7 @@ class Raycast(NodeBuilder):
         ray_direction: InputVector = None,
         ray_length: InputFloat = 100.0,
     ) -> "Raycast":
-        """Create Raycast with operation 'Boolean'."""
+        """Create Raycast with operation 'Boolean'. True or false"""
         return cls(
             data_type="BOOLEAN",
             target_geometry=target_geometry,
@@ -2743,7 +2743,7 @@ class Raycast(NodeBuilder):
         ray_direction: InputVector = None,
         ray_length: InputFloat = 100.0,
     ) -> "Raycast":
-        """Create Raycast with operation 'Vector'."""
+        """Create Raycast with operation 'Vector'. 3D vector with floating-point values"""
         return cls(
             data_type="FLOAT_VECTOR",
             target_geometry=target_geometry,
@@ -2764,7 +2764,7 @@ class Raycast(NodeBuilder):
         ray_direction: InputVector = None,
         ray_length: InputFloat = 100.0,
     ) -> "Raycast":
-        """Create Raycast with operation 'Color'."""
+        """Create Raycast with operation 'Color'. RGBA color with 32-bit floating-point values"""
         return cls(
             data_type="FLOAT_COLOR",
             target_geometry=target_geometry,
@@ -2785,7 +2785,7 @@ class Raycast(NodeBuilder):
         ray_direction: InputVector = None,
         ray_length: InputFloat = 100.0,
     ) -> "Raycast":
-        """Create Raycast with operation 'Quaternion'."""
+        """Create Raycast with operation 'Quaternion'. Floating point quaternion rotation"""
         return cls(
             data_type="QUATERNION",
             target_geometry=target_geometry,
@@ -2797,7 +2797,7 @@ class Raycast(NodeBuilder):
         )
 
     @classmethod
-    def matrix(
+    def input_4x4_matrix(
         cls,
         target_geometry: InputGeometry = None,
         attribute: InputMatrix = None,
@@ -2806,7 +2806,7 @@ class Raycast(NodeBuilder):
         ray_direction: InputVector = None,
         ray_length: InputFloat = 100.0,
     ) -> "Raycast":
-        """Create Raycast with operation '4x4 Matrix'."""
+        """Create Raycast with operation '4x4 Matrix'. Floating point matrix"""
         return cls(
             data_type="FLOAT4X4",
             target_geometry=target_geometry,
@@ -3202,7 +3202,7 @@ class SampleCurve(NodeBuilder):
         factor: InputFloat = 0.0,
         curve_index: InputInteger = 0,
     ) -> "SampleCurve":
-        """Create Sample Curve with operation 'Float'."""
+        """Create Sample Curve with operation 'Float'. Floating-point value"""
         return cls(
             data_type="FLOAT",
             curves=curves,
@@ -3219,7 +3219,7 @@ class SampleCurve(NodeBuilder):
         factor: InputFloat = 0.0,
         curve_index: InputInteger = 0,
     ) -> "SampleCurve":
-        """Create Sample Curve with operation 'Integer'."""
+        """Create Sample Curve with operation 'Integer'. 32-bit integer"""
         return cls(
             data_type="INT",
             curves=curves,
@@ -3236,7 +3236,7 @@ class SampleCurve(NodeBuilder):
         factor: InputFloat = 0.0,
         curve_index: InputInteger = 0,
     ) -> "SampleCurve":
-        """Create Sample Curve with operation 'Boolean'."""
+        """Create Sample Curve with operation 'Boolean'. True or false"""
         return cls(
             data_type="BOOLEAN",
             curves=curves,
@@ -3253,7 +3253,7 @@ class SampleCurve(NodeBuilder):
         factor: InputFloat = 0.0,
         curve_index: InputInteger = 0,
     ) -> "SampleCurve":
-        """Create Sample Curve with operation 'Vector'."""
+        """Create Sample Curve with operation 'Vector'. 3D vector with floating-point values"""
         return cls(
             data_type="FLOAT_VECTOR",
             curves=curves,
@@ -3270,7 +3270,7 @@ class SampleCurve(NodeBuilder):
         factor: InputFloat = 0.0,
         curve_index: InputInteger = 0,
     ) -> "SampleCurve":
-        """Create Sample Curve with operation 'Color'."""
+        """Create Sample Curve with operation 'Color'. RGBA color with 32-bit floating-point values"""
         return cls(
             data_type="FLOAT_COLOR",
             curves=curves,
@@ -3287,7 +3287,7 @@ class SampleCurve(NodeBuilder):
         factor: InputFloat = 0.0,
         curve_index: InputInteger = 0,
     ) -> "SampleCurve":
-        """Create Sample Curve with operation 'Quaternion'."""
+        """Create Sample Curve with operation 'Quaternion'. Floating point quaternion rotation"""
         return cls(
             data_type="QUATERNION",
             curves=curves,
@@ -3297,14 +3297,14 @@ class SampleCurve(NodeBuilder):
         )
 
     @classmethod
-    def matrix(
+    def input_4x4_matrix(
         cls,
         curves: InputGeometry = None,
         value: InputMatrix = None,
         factor: InputFloat = 0.0,
         curve_index: InputInteger = 0,
     ) -> "SampleCurve":
-        """Create Sample Curve with operation '4x4 Matrix'."""
+        """Create Sample Curve with operation '4x4 Matrix'. Floating point matrix"""
         return cls(
             data_type="FLOAT4X4",
             curves=curves,
@@ -3446,7 +3446,7 @@ class SampleIndex(NodeBuilder):
         value: InputFloat = 0.0,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Float'."""
+        """Create Sample Index with operation 'Float'. Floating-point value"""
         return cls(data_type="FLOAT", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3456,7 +3456,7 @@ class SampleIndex(NodeBuilder):
         value: InputInteger = 0,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Integer'."""
+        """Create Sample Index with operation 'Integer'. 32-bit integer"""
         return cls(data_type="INT", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3466,7 +3466,7 @@ class SampleIndex(NodeBuilder):
         value: InputBoolean = False,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Boolean'."""
+        """Create Sample Index with operation 'Boolean'. True or false"""
         return cls(data_type="BOOLEAN", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3476,7 +3476,7 @@ class SampleIndex(NodeBuilder):
         value: InputVector = None,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Vector'."""
+        """Create Sample Index with operation 'Vector'. 3D vector with floating-point values"""
         return cls(
             data_type="FLOAT_VECTOR", geometry=geometry, value=value, index=index
         )
@@ -3488,7 +3488,7 @@ class SampleIndex(NodeBuilder):
         value: InputColor = None,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Color'."""
+        """Create Sample Index with operation 'Color'. RGBA color with 32-bit floating-point values"""
         return cls(data_type="FLOAT_COLOR", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3498,17 +3498,17 @@ class SampleIndex(NodeBuilder):
         value: InputRotation = None,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Quaternion'."""
+        """Create Sample Index with operation 'Quaternion'. Floating point quaternion rotation"""
         return cls(data_type="QUATERNION", geometry=geometry, value=value, index=index)
 
     @classmethod
-    def matrix(
+    def input_4x4_matrix(
         cls,
         geometry: InputGeometry = None,
         value: InputMatrix = None,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation '4x4 Matrix'."""
+        """Create Sample Index with operation '4x4 Matrix'. Floating point matrix"""
         return cls(data_type="FLOAT4X4", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3518,7 +3518,7 @@ class SampleIndex(NodeBuilder):
         value: InputFloat = 0.0,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Point'."""
+        """Create Sample Index with operation 'Point'. Attribute on point"""
         return cls(domain="POINT", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3528,7 +3528,7 @@ class SampleIndex(NodeBuilder):
         value: InputFloat = 0.0,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Edge'."""
+        """Create Sample Index with operation 'Edge'. Attribute on mesh edge"""
         return cls(domain="EDGE", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3538,7 +3538,7 @@ class SampleIndex(NodeBuilder):
         value: InputFloat = 0.0,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Face'."""
+        """Create Sample Index with operation 'Face'. Attribute on mesh faces"""
         return cls(domain="FACE", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3548,7 +3548,7 @@ class SampleIndex(NodeBuilder):
         value: InputFloat = 0.0,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Face Corner'."""
+        """Create Sample Index with operation 'Face Corner'. Attribute on mesh face corner"""
         return cls(domain="CORNER", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3558,7 +3558,7 @@ class SampleIndex(NodeBuilder):
         value: InputFloat = 0.0,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Spline'."""
+        """Create Sample Index with operation 'Spline'. Attribute on spline"""
         return cls(domain="CURVE", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3568,7 +3568,7 @@ class SampleIndex(NodeBuilder):
         value: InputFloat = 0.0,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Instance'."""
+        """Create Sample Index with operation 'Instance'. Attribute on instance"""
         return cls(domain="INSTANCE", geometry=geometry, value=value, index=index)
 
     @classmethod
@@ -3578,7 +3578,7 @@ class SampleIndex(NodeBuilder):
         value: InputFloat = 0.0,
         index: InputInteger = 0,
     ) -> "SampleIndex":
-        """Create Sample Index with operation 'Layer'."""
+        """Create Sample Index with operation 'Layer'. Attribute on Grease Pencil layer"""
         return cls(domain="LAYER", geometry=geometry, value=value, index=index)
 
     @property
@@ -3676,28 +3676,28 @@ class SampleNearest(NodeBuilder):
     def point(
         cls, geometry: InputGeometry = None, sample_position: InputVector = None
     ) -> "SampleNearest":
-        """Create Sample Nearest with operation 'Point'."""
+        """Create Sample Nearest with operation 'Point'. Attribute on point"""
         return cls(domain="POINT", geometry=geometry, sample_position=sample_position)
 
     @classmethod
     def edge(
         cls, geometry: InputGeometry = None, sample_position: InputVector = None
     ) -> "SampleNearest":
-        """Create Sample Nearest with operation 'Edge'."""
+        """Create Sample Nearest with operation 'Edge'. Attribute on mesh edge"""
         return cls(domain="EDGE", geometry=geometry, sample_position=sample_position)
 
     @classmethod
     def face(
         cls, geometry: InputGeometry = None, sample_position: InputVector = None
     ) -> "SampleNearest":
-        """Create Sample Nearest with operation 'Face'."""
+        """Create Sample Nearest with operation 'Face'. Attribute on mesh faces"""
         return cls(domain="FACE", geometry=geometry, sample_position=sample_position)
 
     @classmethod
     def face_corner(
         cls, geometry: InputGeometry = None, sample_position: InputVector = None
     ) -> "SampleNearest":
-        """Create Sample Nearest with operation 'Face Corner'."""
+        """Create Sample Nearest with operation 'Face Corner'. Attribute on mesh face corner"""
         return cls(domain="CORNER", geometry=geometry, sample_position=sample_position)
 
     @property
@@ -3770,7 +3770,7 @@ class SampleNearestSurface(NodeBuilder):
         sample_position: InputVector = None,
         sample_group_id: InputInteger = 0,
     ) -> "SampleNearestSurface":
-        """Create Sample Nearest Surface with operation 'Float'."""
+        """Create Sample Nearest Surface with operation 'Float'. Floating-point value"""
         return cls(
             data_type="FLOAT",
             mesh=mesh,
@@ -3789,7 +3789,7 @@ class SampleNearestSurface(NodeBuilder):
         sample_position: InputVector = None,
         sample_group_id: InputInteger = 0,
     ) -> "SampleNearestSurface":
-        """Create Sample Nearest Surface with operation 'Integer'."""
+        """Create Sample Nearest Surface with operation 'Integer'. 32-bit integer"""
         return cls(
             data_type="INT",
             mesh=mesh,
@@ -3808,7 +3808,7 @@ class SampleNearestSurface(NodeBuilder):
         sample_position: InputVector = None,
         sample_group_id: InputInteger = 0,
     ) -> "SampleNearestSurface":
-        """Create Sample Nearest Surface with operation 'Boolean'."""
+        """Create Sample Nearest Surface with operation 'Boolean'. True or false"""
         return cls(
             data_type="BOOLEAN",
             mesh=mesh,
@@ -3827,7 +3827,7 @@ class SampleNearestSurface(NodeBuilder):
         sample_position: InputVector = None,
         sample_group_id: InputInteger = 0,
     ) -> "SampleNearestSurface":
-        """Create Sample Nearest Surface with operation 'Vector'."""
+        """Create Sample Nearest Surface with operation 'Vector'. 3D vector with floating-point values"""
         return cls(
             data_type="FLOAT_VECTOR",
             mesh=mesh,
@@ -3846,7 +3846,7 @@ class SampleNearestSurface(NodeBuilder):
         sample_position: InputVector = None,
         sample_group_id: InputInteger = 0,
     ) -> "SampleNearestSurface":
-        """Create Sample Nearest Surface with operation 'Color'."""
+        """Create Sample Nearest Surface with operation 'Color'. RGBA color with 32-bit floating-point values"""
         return cls(
             data_type="FLOAT_COLOR",
             mesh=mesh,
@@ -3865,7 +3865,7 @@ class SampleNearestSurface(NodeBuilder):
         sample_position: InputVector = None,
         sample_group_id: InputInteger = 0,
     ) -> "SampleNearestSurface":
-        """Create Sample Nearest Surface with operation 'Quaternion'."""
+        """Create Sample Nearest Surface with operation 'Quaternion'. Floating point quaternion rotation"""
         return cls(
             data_type="QUATERNION",
             mesh=mesh,
@@ -3876,7 +3876,7 @@ class SampleNearestSurface(NodeBuilder):
         )
 
     @classmethod
-    def matrix(
+    def input_4x4_matrix(
         cls,
         mesh: InputGeometry = None,
         value: InputMatrix = None,
@@ -3884,7 +3884,7 @@ class SampleNearestSurface(NodeBuilder):
         sample_position: InputVector = None,
         sample_group_id: InputInteger = 0,
     ) -> "SampleNearestSurface":
-        """Create Sample Nearest Surface with operation '4x4 Matrix'."""
+        """Create Sample Nearest Surface with operation '4x4 Matrix'. Floating point matrix"""
         return cls(
             data_type="FLOAT4X4",
             mesh=mesh,
@@ -4002,7 +4002,7 @@ class SampleUVSurface(NodeBuilder):
         source_uv_map: InputVector = None,
         sample_uv: InputVector = None,
     ) -> "SampleUVSurface":
-        """Create Sample UV Surface with operation 'Float'."""
+        """Create Sample UV Surface with operation 'Float'. Floating-point value"""
         return cls(
             data_type="FLOAT",
             mesh=mesh,
@@ -4019,7 +4019,7 @@ class SampleUVSurface(NodeBuilder):
         source_uv_map: InputVector = None,
         sample_uv: InputVector = None,
     ) -> "SampleUVSurface":
-        """Create Sample UV Surface with operation 'Integer'."""
+        """Create Sample UV Surface with operation 'Integer'. 32-bit integer"""
         return cls(
             data_type="INT",
             mesh=mesh,
@@ -4036,7 +4036,7 @@ class SampleUVSurface(NodeBuilder):
         source_uv_map: InputVector = None,
         sample_uv: InputVector = None,
     ) -> "SampleUVSurface":
-        """Create Sample UV Surface with operation 'Boolean'."""
+        """Create Sample UV Surface with operation 'Boolean'. True or false"""
         return cls(
             data_type="BOOLEAN",
             mesh=mesh,
@@ -4053,7 +4053,7 @@ class SampleUVSurface(NodeBuilder):
         source_uv_map: InputVector = None,
         sample_uv: InputVector = None,
     ) -> "SampleUVSurface":
-        """Create Sample UV Surface with operation 'Vector'."""
+        """Create Sample UV Surface with operation 'Vector'. 3D vector with floating-point values"""
         return cls(
             data_type="FLOAT_VECTOR",
             mesh=mesh,
@@ -4070,7 +4070,7 @@ class SampleUVSurface(NodeBuilder):
         source_uv_map: InputVector = None,
         sample_uv: InputVector = None,
     ) -> "SampleUVSurface":
-        """Create Sample UV Surface with operation 'Color'."""
+        """Create Sample UV Surface with operation 'Color'. RGBA color with 32-bit floating-point values"""
         return cls(
             data_type="FLOAT_COLOR",
             mesh=mesh,
@@ -4087,7 +4087,7 @@ class SampleUVSurface(NodeBuilder):
         source_uv_map: InputVector = None,
         sample_uv: InputVector = None,
     ) -> "SampleUVSurface":
-        """Create Sample UV Surface with operation 'Quaternion'."""
+        """Create Sample UV Surface with operation 'Quaternion'. Floating point quaternion rotation"""
         return cls(
             data_type="QUATERNION",
             mesh=mesh,
@@ -4097,14 +4097,14 @@ class SampleUVSurface(NodeBuilder):
         )
 
     @classmethod
-    def matrix(
+    def input_4x4_matrix(
         cls,
         mesh: InputGeometry = None,
         value: InputMatrix = None,
         source_uv_map: InputVector = None,
         sample_uv: InputVector = None,
     ) -> "SampleUVSurface":
-        """Create Sample UV Surface with operation '4x4 Matrix'."""
+        """Create Sample UV Surface with operation '4x4 Matrix'. Floating point matrix"""
         return cls(
             data_type="FLOAT4X4",
             mesh=mesh,
@@ -4213,7 +4213,7 @@ class ScaleElements(NodeBuilder):
         center: InputVector = None,
         scale_mode: InputMenu | Literal["Uniform", "Single Axis"] = "Uniform",
     ) -> "ScaleElements":
-        """Create Scale Elements with operation 'Face'."""
+        """Create Scale Elements with operation 'Face'. Scale individual faces or neighboring face islands"""
         return cls(
             domain="FACE",
             geometry=geometry,
@@ -4232,7 +4232,7 @@ class ScaleElements(NodeBuilder):
         center: InputVector = None,
         scale_mode: InputMenu | Literal["Uniform", "Single Axis"] = "Uniform",
     ) -> "ScaleElements":
-        """Create Scale Elements with operation 'Edge'."""
+        """Create Scale Elements with operation 'Edge'. Scale individual edges or neighboring edge islands"""
         return cls(
             domain="EDGE",
             geometry=geometry,
@@ -4420,42 +4420,42 @@ class SeparateGeometry(NodeBuilder):
     def point(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SeparateGeometry":
-        """Create Separate Geometry with operation 'Point'."""
+        """Create Separate Geometry with operation 'Point'. Attribute on point"""
         return cls(domain="POINT", geometry=geometry, selection=selection)
 
     @classmethod
     def edge(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SeparateGeometry":
-        """Create Separate Geometry with operation 'Edge'."""
+        """Create Separate Geometry with operation 'Edge'. Attribute on mesh edge"""
         return cls(domain="EDGE", geometry=geometry, selection=selection)
 
     @classmethod
     def face(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SeparateGeometry":
-        """Create Separate Geometry with operation 'Face'."""
+        """Create Separate Geometry with operation 'Face'. Attribute on mesh faces"""
         return cls(domain="FACE", geometry=geometry, selection=selection)
 
     @classmethod
     def spline(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SeparateGeometry":
-        """Create Separate Geometry with operation 'Spline'."""
+        """Create Separate Geometry with operation 'Spline'. Attribute on spline"""
         return cls(domain="CURVE", geometry=geometry, selection=selection)
 
     @classmethod
     def instance(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SeparateGeometry":
-        """Create Separate Geometry with operation 'Instance'."""
+        """Create Separate Geometry with operation 'Instance'. Attribute on instance"""
         return cls(domain="INSTANCE", geometry=geometry, selection=selection)
 
     @classmethod
     def layer(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SeparateGeometry":
-        """Create Separate Geometry with operation 'Layer'."""
+        """Create Separate Geometry with operation 'Layer'. Attribute on Grease Pencil layer"""
         return cls(domain="LAYER", geometry=geometry, selection=selection)
 
     @property
@@ -5103,7 +5103,7 @@ class SetMeshNormal(NodeBuilder):
         edge_sharpness: InputBoolean = False,
         face_sharpness: InputBoolean = False,
     ) -> "SetMeshNormal":
-        """Create Set Mesh Normal with operation 'Point'."""
+        """Create Set Mesh Normal with operation 'Point'. Attribute on point"""
         return cls(
             domain="POINT",
             mesh=mesh,
@@ -5120,7 +5120,7 @@ class SetMeshNormal(NodeBuilder):
         edge_sharpness: InputBoolean = False,
         face_sharpness: InputBoolean = False,
     ) -> "SetMeshNormal":
-        """Create Set Mesh Normal with operation 'Face'."""
+        """Create Set Mesh Normal with operation 'Face'. Attribute on mesh faces"""
         return cls(
             domain="FACE",
             mesh=mesh,
@@ -5137,7 +5137,7 @@ class SetMeshNormal(NodeBuilder):
         edge_sharpness: InputBoolean = False,
         face_sharpness: InputBoolean = False,
     ) -> "SetMeshNormal":
-        """Create Set Mesh Normal with operation 'Face Corner'."""
+        """Create Set Mesh Normal with operation 'Face Corner'. Attribute on mesh face corner"""
         return cls(
             domain="CORNER",
             mesh=mesh,
@@ -5305,28 +5305,28 @@ class SetSelection(NodeBuilder):
     def point(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SetSelection":
-        """Create Set Selection with operation 'Point'."""
+        """Create Set Selection with operation 'Point'. Attribute on point"""
         return cls(domain="POINT", geometry=geometry, selection=selection)
 
     @classmethod
     def edge(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SetSelection":
-        """Create Set Selection with operation 'Edge'."""
+        """Create Set Selection with operation 'Edge'. Attribute on mesh edge"""
         return cls(domain="EDGE", geometry=geometry, selection=selection)
 
     @classmethod
     def face(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SetSelection":
-        """Create Set Selection with operation 'Face'."""
+        """Create Set Selection with operation 'Face'. Attribute on mesh faces"""
         return cls(domain="FACE", geometry=geometry, selection=selection)
 
     @classmethod
     def spline(
         cls, geometry: InputGeometry = None, selection: InputBoolean = True
     ) -> "SetSelection":
-        """Create Set Selection with operation 'Spline'."""
+        """Create Set Selection with operation 'Spline'. Attribute on spline"""
         return cls(domain="CURVE", geometry=geometry, selection=selection)
 
     @property
@@ -5393,7 +5393,7 @@ class SetShadeSmooth(NodeBuilder):
         selection: InputBoolean = True,
         shade_smooth: InputBoolean = True,
     ) -> "SetShadeSmooth":
-        """Create Set Shade Smooth with operation 'Edge'."""
+        """Create Set Shade Smooth with operation 'Edge'. Attribute on mesh edge"""
         return cls(
             domain="EDGE",
             geometry=geometry,
@@ -5408,7 +5408,7 @@ class SetShadeSmooth(NodeBuilder):
         selection: InputBoolean = True,
         shade_smooth: InputBoolean = True,
     ) -> "SetShadeSmooth":
-        """Create Set Shade Smooth with operation 'Face'."""
+        """Create Set Shade Smooth with operation 'Face'. Attribute on mesh faces"""
         return cls(
             domain="FACE",
             geometry=geometry,
@@ -5608,7 +5608,7 @@ class SortElements(NodeBuilder):
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
     ) -> "SortElements":
-        """Create Sort Elements with operation 'Point'."""
+        """Create Sort Elements with operation 'Point'. Attribute on point"""
         return cls(
             domain="POINT",
             geometry=geometry,
@@ -5625,7 +5625,7 @@ class SortElements(NodeBuilder):
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
     ) -> "SortElements":
-        """Create Sort Elements with operation 'Edge'."""
+        """Create Sort Elements with operation 'Edge'. Attribute on mesh edge"""
         return cls(
             domain="EDGE",
             geometry=geometry,
@@ -5642,7 +5642,7 @@ class SortElements(NodeBuilder):
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
     ) -> "SortElements":
-        """Create Sort Elements with operation 'Face'."""
+        """Create Sort Elements with operation 'Face'. Attribute on mesh faces"""
         return cls(
             domain="FACE",
             geometry=geometry,
@@ -5659,7 +5659,7 @@ class SortElements(NodeBuilder):
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
     ) -> "SortElements":
-        """Create Sort Elements with operation 'Spline'."""
+        """Create Sort Elements with operation 'Spline'. Attribute on spline"""
         return cls(
             domain="CURVE",
             geometry=geometry,
@@ -5676,7 +5676,7 @@ class SortElements(NodeBuilder):
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
     ) -> "SortElements":
-        """Create Sort Elements with operation 'Instance'."""
+        """Create Sort Elements with operation 'Instance'. Attribute on instance"""
         return cls(
             domain="INSTANCE",
             geometry=geometry,
@@ -5848,7 +5848,7 @@ class SplitToInstances(NodeBuilder):
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
     ) -> "SplitToInstances":
-        """Create Split to Instances with operation 'Point'."""
+        """Create Split to Instances with operation 'Point'. Attribute on point"""
         return cls(
             domain="POINT", geometry=geometry, selection=selection, group_id=group_id
         )
@@ -5860,7 +5860,7 @@ class SplitToInstances(NodeBuilder):
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
     ) -> "SplitToInstances":
-        """Create Split to Instances with operation 'Edge'."""
+        """Create Split to Instances with operation 'Edge'. Attribute on mesh edge"""
         return cls(
             domain="EDGE", geometry=geometry, selection=selection, group_id=group_id
         )
@@ -5872,7 +5872,7 @@ class SplitToInstances(NodeBuilder):
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
     ) -> "SplitToInstances":
-        """Create Split to Instances with operation 'Face'."""
+        """Create Split to Instances with operation 'Face'. Attribute on mesh faces"""
         return cls(
             domain="FACE", geometry=geometry, selection=selection, group_id=group_id
         )
@@ -5884,7 +5884,7 @@ class SplitToInstances(NodeBuilder):
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
     ) -> "SplitToInstances":
-        """Create Split to Instances with operation 'Spline'."""
+        """Create Split to Instances with operation 'Spline'. Attribute on spline"""
         return cls(
             domain="CURVE", geometry=geometry, selection=selection, group_id=group_id
         )
@@ -5896,7 +5896,7 @@ class SplitToInstances(NodeBuilder):
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
     ) -> "SplitToInstances":
-        """Create Split to Instances with operation 'Instance'."""
+        """Create Split to Instances with operation 'Instance'. Attribute on instance"""
         return cls(
             domain="INSTANCE", geometry=geometry, selection=selection, group_id=group_id
         )
@@ -5908,7 +5908,7 @@ class SplitToInstances(NodeBuilder):
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
     ) -> "SplitToInstances":
-        """Create Split to Instances with operation 'Layer'."""
+        """Create Split to Instances with operation 'Layer'. Attribute on Grease Pencil layer"""
         return cls(
             domain="LAYER", geometry=geometry, selection=selection, group_id=group_id
         )

--- a/src/nodebpy/nodes/geometry/grid.py
+++ b/src/nodebpy/nodes/geometry/grid.py
@@ -1566,7 +1566,7 @@ class StoreNamedGrid(NodeBuilder):
         name: InputString = "",
         grid: InputBoolean = False,
     ) -> "StoreNamedGrid":
-        """Create Store Named Grid with operation 'Boolean'."""
+        """Create Store Named Grid with operation 'Boolean'. Boolean"""
         return cls(data_type="BOOLEAN", volume=volume, name=name, grid=grid)
 
     @classmethod
@@ -1576,7 +1576,7 @@ class StoreNamedGrid(NodeBuilder):
         name: InputString = "",
         grid: InputFloat = 0.0,
     ) -> "StoreNamedGrid":
-        """Create Store Named Grid with operation 'Float'."""
+        """Create Store Named Grid with operation 'Float'. Single precision float"""
         return cls(data_type="FLOAT", volume=volume, name=name, grid=grid)
 
     @classmethod
@@ -1586,7 +1586,7 @@ class StoreNamedGrid(NodeBuilder):
         name: InputString = "",
         grid: InputInteger = 0,
     ) -> "StoreNamedGrid":
-        """Create Store Named Grid with operation 'Integer'."""
+        """Create Store Named Grid with operation 'Integer'. 32-bit integer"""
         return cls(data_type="INT", volume=volume, name=name, grid=grid)
 
     @classmethod
@@ -1596,7 +1596,7 @@ class StoreNamedGrid(NodeBuilder):
         name: InputString = "",
         grid: InputVector = None,
     ) -> "StoreNamedGrid":
-        """Create Store Named Grid with operation 'Vector'."""
+        """Create Store Named Grid with operation 'Vector'. 3D float vector"""
         return cls(data_type="VECTOR_FLOAT", volume=volume, name=name, grid=grid)
 
     @property

--- a/src/nodebpy/nodes/geometry/input.py
+++ b/src/nodebpy/nodes/geometry/input.py
@@ -1540,37 +1540,37 @@ class NamedAttribute(NodeBuilder):
 
     @classmethod
     def float(cls, name: InputString = "") -> "NamedAttribute":
-        """Create Named Attribute with operation 'Float'."""
+        """Create Named Attribute with operation 'Float'. Floating-point value"""
         return cls(data_type="FLOAT", name=name)
 
     @classmethod
     def integer(cls, name: InputString = "") -> "NamedAttribute":
-        """Create Named Attribute with operation 'Integer'."""
+        """Create Named Attribute with operation 'Integer'. 32-bit integer"""
         return cls(data_type="INT", name=name)
 
     @classmethod
     def boolean(cls, name: InputString = "") -> "NamedAttribute":
-        """Create Named Attribute with operation 'Boolean'."""
+        """Create Named Attribute with operation 'Boolean'. True or false"""
         return cls(data_type="BOOLEAN", name=name)
 
     @classmethod
     def vector(cls, name: InputString = "") -> "NamedAttribute":
-        """Create Named Attribute with operation 'Vector'."""
+        """Create Named Attribute with operation 'Vector'. 3D vector with floating-point values"""
         return cls(data_type="FLOAT_VECTOR", name=name)
 
     @classmethod
     def color(cls, name: InputString = "") -> "NamedAttribute":
-        """Create Named Attribute with operation 'Color'."""
+        """Create Named Attribute with operation 'Color'. RGBA color with 32-bit floating-point values"""
         return cls(data_type="FLOAT_COLOR", name=name)
 
     @classmethod
     def quaternion(cls, name: InputString = "") -> "NamedAttribute":
-        """Create Named Attribute with operation 'Quaternion'."""
+        """Create Named Attribute with operation 'Quaternion'. Floating point quaternion rotation"""
         return cls(data_type="QUATERNION", name=name)
 
     @classmethod
-    def matrix(cls, name: InputString = "") -> "NamedAttribute":
-        """Create Named Attribute with operation '4x4 Matrix'."""
+    def input_4x4_matrix(cls, name: InputString = "") -> "NamedAttribute":
+        """Create Named Attribute with operation '4x4 Matrix'. Floating point matrix"""
         return cls(data_type="FLOAT4X4", name=name)
 
     @property

--- a/src/nodebpy/nodes/geometry/manual.py
+++ b/src/nodebpy/nodes/geometry/manual.py
@@ -1,14 +1,18 @@
 from typing import Any, Literal
 
 import bpy
-
 from bpy.types import NodeSocket
 
 from ...builder import (
     BaseNode as NodeBuilder,
+)
+from ...builder import (
     DynamicInputsMixin,
-    Socket as SocketLinker,
     SocketError,
+    TreeBuilder,
+)
+from ...builder import (
+    Socket as SocketLinker,
 )
 from ...types import (
     SOCKET_TYPES,
@@ -82,6 +86,15 @@ __all__ = (
     "Compare",
     "AttributeStatistic",
 )
+
+
+def tree(
+    name: str = "Geometry Node Group",
+    *,
+    collapse: bool = False,
+    arrange: Literal["sugiyama", "simple"] | None = "sugiyama",
+) -> TreeBuilder:
+    return TreeBuilder.geometry(name, collapse=collapse, arrange=arrange)
 
 
 class Bake(NodeBuilder, DynamicInputsMixin):

--- a/src/nodebpy/nodes/geometry/output.py
+++ b/src/nodebpy/nodes/geometry/output.py
@@ -35,37 +35,37 @@ class Viewer(NodeBuilder):
 
     @classmethod
     def point(cls) -> "Viewer":
-        """Create Viewer with operation 'Point'."""
+        """Create Viewer with operation 'Point'. Attribute on point"""
         return cls(domain="POINT")
 
     @classmethod
     def edge(cls) -> "Viewer":
-        """Create Viewer with operation 'Edge'."""
+        """Create Viewer with operation 'Edge'. Attribute on mesh edge"""
         return cls(domain="EDGE")
 
     @classmethod
     def face(cls) -> "Viewer":
-        """Create Viewer with operation 'Face'."""
+        """Create Viewer with operation 'Face'. Attribute on mesh faces"""
         return cls(domain="FACE")
 
     @classmethod
     def face_corner(cls) -> "Viewer":
-        """Create Viewer with operation 'Face Corner'."""
+        """Create Viewer with operation 'Face Corner'. Attribute on mesh face corner"""
         return cls(domain="CORNER")
 
     @classmethod
     def spline(cls) -> "Viewer":
-        """Create Viewer with operation 'Spline'."""
+        """Create Viewer with operation 'Spline'. Attribute on spline"""
         return cls(domain="CURVE")
 
     @classmethod
     def instance(cls) -> "Viewer":
-        """Create Viewer with operation 'Instance'."""
+        """Create Viewer with operation 'Instance'. Attribute on instance"""
         return cls(domain="INSTANCE")
 
     @classmethod
     def layer(cls) -> "Viewer":
-        """Create Viewer with operation 'Layer'."""
+        """Create Viewer with operation 'Layer'. Attribute on Grease Pencil layer"""
         return cls(domain="LAYER")
 
     @property

--- a/src/nodebpy/nodes/geometry/vector.py
+++ b/src/nodebpy/nodes/geometry/vector.py
@@ -172,28 +172,28 @@ class VectorMath(NodeBuilder):
     def add(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Add'."""
+        """Create Vector Math with operation 'Add'. A + B"""
         return cls(operation="ADD", vector=vector, vector_001=vector_001)
 
     @classmethod
     def subtract(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Subtract'."""
+        """Create Vector Math with operation 'Subtract'. A - B"""
         return cls(operation="SUBTRACT", vector=vector, vector_001=vector_001)
 
     @classmethod
     def multiply(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Multiply'."""
+        """Create Vector Math with operation 'Multiply'. Entry-wise multiply"""
         return cls(operation="MULTIPLY", vector=vector, vector_001=vector_001)
 
     @classmethod
     def divide(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Divide'."""
+        """Create Vector Math with operation 'Divide'. Entry-wise divide"""
         return cls(operation="DIVIDE", vector=vector, vector_001=vector_001)
 
     @classmethod
@@ -203,7 +203,7 @@ class VectorMath(NodeBuilder):
         vector_001: InputVector = None,
         vector_002: InputVector = None,
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Multiply Add'."""
+        """Create Vector Math with operation 'Multiply Add'. A * B + C"""
         return cls(
             operation="MULTIPLY_ADD",
             vector=vector,
@@ -215,21 +215,21 @@ class VectorMath(NodeBuilder):
     def cross_product(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Cross Product'."""
+        """Create Vector Math with operation 'Cross Product'. A cross B"""
         return cls(operation="CROSS_PRODUCT", vector=vector, vector_001=vector_001)
 
     @classmethod
     def project(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Project'."""
+        """Create Vector Math with operation 'Project'. Project A onto B"""
         return cls(operation="PROJECT", vector=vector, vector_001=vector_001)
 
     @classmethod
     def reflect(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Reflect'."""
+        """Create Vector Math with operation 'Reflect'. Reflect A around the normal B. B does not need to be normalized."""
         return cls(operation="REFLECT", vector=vector, vector_001=vector_001)
 
     @classmethod
@@ -239,7 +239,7 @@ class VectorMath(NodeBuilder):
         vector_001: InputVector = None,
         scale: InputFloat = 1.0,
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Refract'."""
+        """Create Vector Math with operation 'Refract'. For a given incident vector A, surface normal B and ratio of indices of refraction, Ior, refract returns the refraction vector, R"""
         return cls(
             operation="REFRACT", vector=vector, vector_001=vector_001, scale=scale
         )
@@ -251,7 +251,7 @@ class VectorMath(NodeBuilder):
         vector_001: InputVector = None,
         vector_002: InputVector = None,
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Faceforward'."""
+        """Create Vector Math with operation 'Faceforward'. Orients a vector A to point away from a surface B as defined by its normal C. Returns (dot(B, C) < 0) ? A : -A"""
         return cls(
             operation="FACEFORWARD",
             vector=vector,
@@ -263,82 +263,82 @@ class VectorMath(NodeBuilder):
     def dot_product(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Dot Product'."""
+        """Create Vector Math with operation 'Dot Product'. A dot B"""
         return cls(operation="DOT_PRODUCT", vector=vector, vector_001=vector_001)
 
     @classmethod
     def distance(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Distance'."""
+        """Create Vector Math with operation 'Distance'. Distance between A and B"""
         return cls(operation="DISTANCE", vector=vector, vector_001=vector_001)
 
     @classmethod
     def length(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Length'."""
+        """Create Vector Math with operation 'Length'. Length of A"""
         return cls(operation="LENGTH", vector=vector)
 
     @classmethod
     def scale(cls, vector: InputVector = None, scale: InputFloat = 1.0) -> "VectorMath":
-        """Create Vector Math with operation 'Scale'."""
+        """Create Vector Math with operation 'Scale'. A multiplied by Scale"""
         return cls(operation="SCALE", vector=vector, scale=scale)
 
     @classmethod
     def normalize(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Normalize'."""
+        """Create Vector Math with operation 'Normalize'. Normalize A"""
         return cls(operation="NORMALIZE", vector=vector)
 
     @classmethod
     def absolute(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Absolute'."""
+        """Create Vector Math with operation 'Absolute'. Entry-wise absolute"""
         return cls(operation="ABSOLUTE", vector=vector)
 
     @classmethod
     def power(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Power'."""
+        """Create Vector Math with operation 'Power'. Entry-wise power"""
         return cls(operation="POWER", vector=vector, vector_001=vector_001)
 
     @classmethod
     def sign(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Sign'."""
+        """Create Vector Math with operation 'Sign'. Entry-wise sign"""
         return cls(operation="SIGN", vector=vector)
 
     @classmethod
     def minimum(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Minimum'."""
+        """Create Vector Math with operation 'Minimum'. Entry-wise minimum"""
         return cls(operation="MINIMUM", vector=vector, vector_001=vector_001)
 
     @classmethod
     def maximum(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Maximum'."""
+        """Create Vector Math with operation 'Maximum'. Entry-wise maximum"""
         return cls(operation="MAXIMUM", vector=vector, vector_001=vector_001)
 
     @classmethod
     def floor(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Floor'."""
+        """Create Vector Math with operation 'Floor'. Entry-wise floor"""
         return cls(operation="FLOOR", vector=vector)
 
     @classmethod
     def ceil(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Ceil'."""
+        """Create Vector Math with operation 'Ceil'. Entry-wise ceil"""
         return cls(operation="CEIL", vector=vector)
 
     @classmethod
     def fraction(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Fraction'."""
+        """Create Vector Math with operation 'Fraction'. The fraction part of A entry-wise"""
         return cls(operation="FRACTION", vector=vector)
 
     @classmethod
     def modulo(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Modulo'."""
+        """Create Vector Math with operation 'Modulo'. Entry-wise modulo using fmod(A,B)"""
         return cls(operation="MODULO", vector=vector, vector_001=vector_001)
 
     @classmethod
@@ -348,7 +348,7 @@ class VectorMath(NodeBuilder):
         vector_001: InputVector = None,
         vector_002: InputVector = None,
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Wrap'."""
+        """Create Vector Math with operation 'Wrap'. Entry-wise wrap(A,B)"""
         return cls(
             operation="WRAP",
             vector=vector,
@@ -360,22 +360,22 @@ class VectorMath(NodeBuilder):
     def snap(
         cls, vector: InputVector = None, vector_001: InputVector = None
     ) -> "VectorMath":
-        """Create Vector Math with operation 'Snap'."""
+        """Create Vector Math with operation 'Snap'. Round A to the largest integer multiple of B less than or equal A"""
         return cls(operation="SNAP", vector=vector, vector_001=vector_001)
 
     @classmethod
     def sine(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Sine'."""
+        """Create Vector Math with operation 'Sine'. Entry-wise sin(A)"""
         return cls(operation="SINE", vector=vector)
 
     @classmethod
     def cosine(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Cosine'."""
+        """Create Vector Math with operation 'Cosine'. Entry-wise cos(A)"""
         return cls(operation="COSINE", vector=vector)
 
     @classmethod
     def tangent(cls, vector: InputVector = None) -> "VectorMath":
-        """Create Vector Math with operation 'Tangent'."""
+        """Create Vector Math with operation 'Tangent'. Entry-wise tan(A)"""
         return cls(operation="TANGENT", vector=vector)
 
     @property

--- a/src/nodebpy/nodes/shader/__init__.py
+++ b/src/nodebpy/nodes/shader/__init__.py
@@ -5,6 +5,9 @@ from .manual import (
     RepeatInput,
     RepeatOutput,
     RepeatZone,
+    Attribute,
+    tree,
+    material,
 )
 from ..geometry.color import (
     Gamma,
@@ -83,7 +86,6 @@ from .shader import (
 )
 from .input import (
     AmbientOcclusion,
-    Attribute,
     Bevel,
     CameraData,
     Color,
@@ -252,4 +254,6 @@ __all__ = (
     "WhiteNoiseTexture",
     "Wireframe",
     "WorldOutput",
+    "material",
+    "tree",
 )

--- a/src/nodebpy/nodes/shader/input.py
+++ b/src/nodebpy/nodes/shader/input.py
@@ -95,68 +95,6 @@ class AmbientOcclusion(NodeBuilder):
         self.node.only_local = value
 
 
-class Attribute(NodeBuilder):
-    """
-    Retrieve attributes attached to objects or geometry
-    """
-
-    _bl_idname = "ShaderNodeAttribute"
-    node: bpy.types.ShaderNodeAttribute
-
-    def __init__(
-        self,
-        attribute_type: Literal[
-            "GEOMETRY", "OBJECT", "INSTANCER", "VIEW_LAYER"
-        ] = "GEOMETRY",
-        attribute_name: str = "",
-    ):
-        super().__init__()
-        key_args = {}
-        self.attribute_type = attribute_type
-        self.attribute_name = attribute_name
-        self._establish_links(**key_args)
-
-    @property
-    def o_color(self) -> ColorSocket:
-        """Output socket: Color"""
-        return self.outputs.get("Color")
-
-    @property
-    def o_vector(self) -> VectorSocket:
-        """Output socket: Vector"""
-        return self.outputs.get("Vector")
-
-    @property
-    def o_fac(self) -> FloatSocket:
-        """Output socket: Factor"""
-        return self.outputs.get("Fac")
-
-    @property
-    def o_alpha(self) -> FloatSocket:
-        """Output socket: Alpha"""
-        return self.outputs.get("Alpha")
-
-    @property
-    def attribute_type(
-        self,
-    ) -> Literal["GEOMETRY", "OBJECT", "INSTANCER", "VIEW_LAYER"]:
-        return self.node.attribute_type
-
-    @attribute_type.setter
-    def attribute_type(
-        self, value: Literal["GEOMETRY", "OBJECT", "INSTANCER", "VIEW_LAYER"]
-    ):
-        self.node.attribute_type = value
-
-    @property
-    def attribute_name(self) -> str:
-        return self.node.attribute_name
-
-    @attribute_name.setter
-    def attribute_name(self, value: str):
-        self.node.attribute_name = value
-
-
 class Bevel(NodeBuilder):
     """
         Generates normals with round corners.

--- a/src/nodebpy/nodes/shader/manual.py
+++ b/src/nodebpy/nodes/shader/manual.py
@@ -1,12 +1,27 @@
 from typing import Literal
 
-import bpy
+from bpy.types import ShaderNodeAttribute
 
-from ...builder import TreeBuilder
+from ...builder import (
+    ColorSocket,
+    FloatSocket,
+    MaterialBuilder,
+    NodeBuilder,
+    TreeBuilder,
+    VectorSocket,
+)
 from ..geometry import RepeatInput, RepeatOutput, RepeatZone
 from ..geometry.manual import _MenuSwitchBase
 
-__all__ = ["MenuSwitch", "RepeatInput", "RepeatOutput", "RepeatZone", "tree"]
+__all__ = [
+    "MenuSwitch",
+    "RepeatInput",
+    "RepeatOutput",
+    "RepeatZone",
+    "Attribute",
+    "tree",
+    "material",
+]
 
 
 def tree(
@@ -22,16 +37,15 @@ def tree(
 
 
 def material(
-    name: str = "Material Nodes",
+    name: str = "New Material",
     *,
     collapse: bool = False,
     arrange: Literal["sugiyama", "simple"] | None = "sugiyama",
     fake_user: bool = False,
-) -> TreeBuilder:
-    material = bpy.data.materials.new(name)
-    tree = material.node_tree
-    assert tree
-    return TreeBuilder(tree, collapse=collapse, arrange=arrange, fake_user=fake_user)
+) -> MaterialBuilder:
+    return MaterialBuilder(
+        name, collapse=collapse, arrange=arrange, fake_user=fake_user
+    )
 
 
 class MenuSwitch(_MenuSwitchBase):
@@ -46,3 +60,85 @@ class MenuSwitch(_MenuSwitchBase):
     closure = _MenuSwitchBase._typed("CLOSURE")
     bundle = _MenuSwitchBase._typed("BUNDLE")
     shader = _MenuSwitchBase._typed("SHADER")
+
+
+class Attribute(NodeBuilder):
+    """
+    Retrieve attributes attached to objects or geometry
+    """
+
+    _bl_idname = "ShaderNodeAttribute"
+    node: ShaderNodeAttribute
+
+    def __init__(
+        self,
+        attribute_type: Literal[
+            "GEOMETRY", "OBJECT", "INSTANCER", "VIEW_LAYER"
+        ] = "GEOMETRY",
+        attribute_name: str = "",
+    ):
+        super().__init__()
+        key_args = {}
+        self.attribute_type = attribute_type
+        self.attribute_name = attribute_name
+        self._establish_links(**key_args)
+
+    @classmethod
+    def geometry(cls, attribute_name: str = "") -> "Attribute":
+        """Create Attribute with operation 'Geometry'."""
+        return cls(attribute_type="GEOMETRY", attribute_name=attribute_name)
+
+    @classmethod
+    def object(cls, attribute_name: str = "") -> "Attribute":
+        """Create Attribute with operation 'Object'."""
+        return cls(attribute_type="OBJECT", attribute_name=attribute_name)
+
+    @classmethod
+    def instancer(cls, attribute_name: str = "") -> "Attribute":
+        """Create Attribute with operation 'Instancer'."""
+        return cls(attribute_type="INSTANCER", attribute_name=attribute_name)
+
+    @classmethod
+    def view_layer(cls, attribute_name: str = "") -> "Attribute":
+        """Create Attribute with operation 'View Layer'."""
+        return cls(attribute_type="VIEW_LAYER", attribute_name=attribute_name)
+
+    @property
+    def o_color(self) -> ColorSocket:
+        """Output socket: Color"""
+        return self.outputs.get("Color")
+
+    @property
+    def o_vector(self) -> VectorSocket:
+        """Output socket: Vector"""
+        return self.outputs.get("Vector")
+
+    @property
+    def o_fac(self) -> FloatSocket:
+        """Output socket: Factor"""
+        return self.outputs.get("Fac")
+
+    @property
+    def o_alpha(self) -> FloatSocket:
+        """Output socket: Alpha"""
+        return self.outputs.get("Alpha")
+
+    @property
+    def attribute_type(
+        self,
+    ) -> Literal["GEOMETRY", "OBJECT", "INSTANCER", "VIEW_LAYER"]:
+        return self.node.attribute_type
+
+    @attribute_type.setter
+    def attribute_type(
+        self, value: Literal["GEOMETRY", "OBJECT", "INSTANCER", "VIEW_LAYER"]
+    ):
+        self.node.attribute_type = value
+
+    @property
+    def attribute_name(self) -> str:
+        return self.node.attribute_name
+
+    @attribute_name.setter
+    def attribute_name(self, value: str):
+        self.node.attribute_name = value

--- a/src/nodebpy/nodes/shader/manual.py
+++ b/src/nodebpy/nodes/shader/manual.py
@@ -1,7 +1,37 @@
+from typing import Literal
+
+import bpy
+
+from ...builder import TreeBuilder
 from ..geometry import RepeatInput, RepeatOutput, RepeatZone
 from ..geometry.manual import _MenuSwitchBase
 
-__all__ = ["MenuSwitch", "RepeatInput", "RepeatOutput", "RepeatZone"]
+__all__ = ["MenuSwitch", "RepeatInput", "RepeatOutput", "RepeatZone", "tree"]
+
+
+def tree(
+    name: str = "Shader Nodes",
+    *,
+    collapse: bool = False,
+    arrange: Literal["sugiyama", "simple"] | None = "sugiyama",
+    fake_user: bool = False,
+) -> TreeBuilder:
+    return TreeBuilder.shader(
+        name, collapse=collapse, arrange=arrange, fake_user=fake_user
+    )
+
+
+def material(
+    name: str = "Material Nodes",
+    *,
+    collapse: bool = False,
+    arrange: Literal["sugiyama", "simple"] | None = "sugiyama",
+    fake_user: bool = False,
+) -> TreeBuilder:
+    material = bpy.data.materials.new(name)
+    tree = material.node_tree
+    assert tree
+    return TreeBuilder(tree, collapse=collapse, arrange=arrange, fake_user=fake_user)
 
 
 class MenuSwitch(_MenuSwitchBase):

--- a/tests/test_compositor.py
+++ b/tests/test_compositor.py
@@ -4,7 +4,7 @@ from nodebpy import sockets as s
 
 
 def test_initial_compositor():
-    with TreeBuilder.compositor("comp", fake_user=True) as t:
+    with c.tree("comp", fake_user=True) as t:
         with t.inputs:
             image = s.SocketColor("Image")
             depth = s.SocketFloat("Depth")
@@ -24,10 +24,10 @@ def test_initial_compositor():
         with t.outputs:
             output_color = s.SocketColor("Image")
 
-        ao_factor = (ao >> c.InvertColor()) ** 0.94 >> c.Kuwahara(..., size=4.0)
+        ao_factor = c.InvertColor(ao) ** 0.94 >> c.Kuwahara(..., size=4.0)
         active_image = c.Mix.color(ao_factor, image)
-        depth_line = c.Filter(depth, type="Sobel") > (outline_depth / 100)
-        normal_line = c.Filter(normal, type="Sobel") > 1.5
+        depth_line = c.Filter.sobel(depth) > (outline_depth / 100)
+        normal_line = c.Filter.sobel(normal) > 1.5
         outline_comp = (
             (depth_line + normal_line)
             >> c.AntiAliasing()

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -45,7 +45,7 @@ def test_capture_attribute():
 
 
 def test_join_geometry():
-    with TreeBuilder("TestJoinGeometry") as tree:
+    with g.tree() as tree:
         items = [g.Cube(), g.UVSphere(), g.Cone(), g.Cylinder(), g.Grid()]
         join = g.JoinGeometry(*items)
 
@@ -56,7 +56,7 @@ def test_join_geometry():
 
 
 def test_socket_selection():
-    with TreeBuilder("AnotherTree"):
+    with g.tree("AnotherTree"):
         pos = g.SetPosition()
         vec = g.Vector()
 

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -68,7 +68,7 @@ def test_shader_menu_switch():
 
 
 def test_color_shader():
-    with TreeBuilder.shader():
+    with s.tree():
         mix_shader = s.MixShader(1.0, s.Color())
         assert (
             mix_shader.node.inputs["Shader"].links[0].from_node.bl_idname
@@ -81,10 +81,9 @@ def test_color_shader():
 def test_material_node_cartoon():
     with s.material("Cartoon", fake_user=True) as mat:
         mat.nodes.clear()
-        output = s.MaterialOutput(surface=s.Attribute("GEOMETRY", "Color"))
-        aov = s.AovOutput(
-            value=s.Attribute.geometry("sec_struct"), aov_name="sec_struct"
-        )
+        output = s.MaterialOutput(surface=s.Attribute.geometry("Color").o_color)
+        attr = s.Attribute.geometry("sec_struct")
+        aov = s.AovOutput(value=attr, aov_name="sec_struct")
 
     assert (
         output.node.inputs["Surface"].links[0].from_node.bl_idname
@@ -95,3 +94,5 @@ def test_material_node_cartoon():
     )
     assert "Cartoon" in bpy.data.materials
     assert "Cartoon" not in bpy.data.node_groups
+    assert attr.attribute_name == "sec_struct"
+    assert attr.attribute_type == "GEOMETRY"

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -78,13 +78,12 @@ def test_color_shader():
             _ = s.Mix.color(0.5, mix_shader)
 
 
-def material_node_cartoon() -> bpy.types.Material:
-    mat = bpy.data.materials.new(name="Cartoon")
-    with TreeBuilder.shader(mat.node_tree) as tree:
-        tree.nodes.clear()
+def test_material_node_cartoon():
+    with s.material("Cartoon", fake_user=True) as mat:
+        mat.nodes.clear()
         output = s.MaterialOutput(surface=s.Attribute("GEOMETRY", "Color"))
         aov = s.AovOutput(
-            value=s.Attribute("GEOMETRY", "sec_struct"), aov_name="sec_struct"
+            value=s.Attribute.geometry("sec_struct"), aov_name="sec_struct"
         )
 
     assert (
@@ -94,3 +93,5 @@ def material_node_cartoon() -> bpy.types.Material:
     assert (
         aov.node.inputs["Value"].links[0].from_node.bl_idname == s.Attribute._bl_idname
     )
+    assert "Cartoon" in bpy.data.materials
+    assert "Cartoon" not in bpy.data.node_groups

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -1,20 +1,20 @@
 import bpy
 import pytest
 
-from nodebpy import TreeBuilder, sockets
 from nodebpy import shader as s
+from nodebpy import sockets
 from nodebpy.builder import SocketError
 
 
 def test_simple_shader():
-    with TreeBuilder.shader() as tree:
+    with s.tree() as tree:
         prin = s.PrincipledBSDF()
         with tree.outputs:
             _ = prin >> sockets.SocketShader()
 
 
 def test_shader_math():
-    with TreeBuilder.shader() as tree:
+    with s.tree() as tree:
         comp = s.Geometry().o_random_per_island >= 10.0
         prin = s.PrincipledBSDF(ior=comp)
         with tree.outputs:
@@ -31,7 +31,7 @@ def test_shader_math():
 
 
 def test_shader_menu_switch():
-    with TreeBuilder.shader() as tree:
+    with s.tree() as tree:
         menu = s.MenuSwitch.shader(*[s.PrincipledBSDF() for _ in range(10)])
         with tree.outputs:
             _ = menu >> sockets.SocketShader()
@@ -39,7 +39,7 @@ def test_shader_menu_switch():
     assert len(menu.node.enum_items) == 10
     assert menu.node.outputs[0].links
 
-    with TreeBuilder.shader() as tree:
+    with s.tree() as tree:
         menu = s.MenuSwitch.float(
             **{f"Input_{i}": float(value) for i, value in enumerate(range(10))}
         )
@@ -51,7 +51,7 @@ def test_shader_menu_switch():
         assert f"Input_{i}" == input.name
         assert float(i) == input.socket.default_value
 
-    with TreeBuilder.shader() as tree:
+    with s.tree() as tree:
         menu = s.MenuSwitch.float(
             **{f"Input_{i}": s.Value(value) for i, value in enumerate(range(10))}
         )


### PR DESCRIPTION
We can now use `g.tree()` instead of `TreeBuilder.geometry()`. This reduces the number of imports that are required, as a user can just import the geometry module.
