### PR TITLE
`len()` for TreeBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ We should know as much ahead of time as possible if our network will actually bu
   - `RandomValue` creates a random value node
     - `RandomValue.vector()` creates it set to `"VECTOR"` data type and
       provides arguments for IDE auto-complete
-- Inputs and outputs from a node are prefixed with `i_*` and `o_`:
-  - `AccumulateField().o_total` returns the output `Total` socket
-  - `AccumulateField().i_value` returns the input `Value` socket
+- Inputs and outputs from a node are prefixed with `i.*` and `o.*`:
+  - `AccumulateField().o.total` returns the output `Total` socket
+  - `AccumulateField().i.value` returns the input `Value` socket
 - If inputs are subject to change depending on enums, provide separate
   constructor methods that provide related inputs as arguments. There
   should be no guessing involved and IDEs should provide documentation

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -7,6 +7,7 @@ title: Changelog
 ### Enhancements
 
 - Added changelog to the documentation to better track and explain changes in the project.
+- Support `len(tree.inputs)` and `len(tree.outputs)` to get the number of inputs and outputs in the tree. ([#43](https://github.com/BradyAJohnston/nodebpy/pull/43))
 
 ## v0.10.1 — 2026-04-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nodebpy"
-version = "0.10.1"
+version = "0.10.2"
 description = "Build nodes trees in Blender more elegantly with code"
 readme = "README.md"
 authors = [

--- a/src/nodebpy/builder/tree.py
+++ b/src/nodebpy/builder/tree.py
@@ -595,6 +595,15 @@ class SocketContext:
         SocketContext._direction = None
         SocketContext._active_context = None
 
+    def __len__(self) -> int:
+        return len(
+            list(
+                item
+                for item in self.tree.interface.items_tree
+                if item.in_out == self._direction
+            )
+        )
+
 
 class DirectionalContext(SocketContext):
     """Base class for directional socket contexts"""

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,4 +1,7 @@
 import itertools
+from functools import reduce
+from itertools import product
+from operator import and_
 
 import bpy
 import pytest
@@ -818,8 +821,24 @@ def test_compare_node_data_types():
         assert comp.operation == "NOT_EQUAL"
 
 
-# @g.tree("SomeTreeName")
-# def tree_builder(size: InputVector = None):
-#     cube = g.Cube(size=size)
-#     cube = cube >> g.SetPosition(offset=g.NoiseTexture().o.color * 0.1)
-#     return cube.o.mesh
+def test_decoder_8bit():
+    # this should actually be 8 bits but it takes a bit longer to run through
+    # (~20 seconds) so for testing we can keep it much smaller. It's a nice
+    # clean implementation and good example of the code in action.
+    N_BITS = 4
+    with g.tree("8-Bit Decoder", arrange="simple") as tree:
+        bits = [tree.inputs.boolean(f"Bit {i}") for i in range(N_BITS)]
+        not_bits = [g.BooleanMath.l_not(b) for b in bits]
+
+        for i, combo in enumerate(product((False, True), repeat=N_BITS)):
+            terms = [b if on else nb for b, nb, on in zip(bits, not_bits, combo)]
+            reduce(and_, terms) >> tree.outputs.boolean(f"Out {i}")
+
+    assert len(tree) == 54
+    assert len(tree.inputs) == 4
+    assert len(tree.outputs) == 16
+    assert all(
+        i.links[0].from_node.operation == "AND"
+        for i in tree.nodes["Group Output"].inputs
+        if i.identifier != "__extend__"
+    )


### PR DESCRIPTION
Example bit decoder test and support len(tree.inputs) and len(tree.outptus).

- **add len() for TreeBuilder and example bit decoder**
- **bump version**
