### PR TITLE
FIX: Correctly output type from chain of `>>`

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,30 +2,37 @@
 title: Changelog
 ---
 
-## Unreleased
+## v0.11.1
+
+### Bug Fixes
+- Fix type inference for the `>>` operator in chains, properly propagating the correct node's return type.
+
+## v0.11.0 — 2026-04-24
 
 ### Enhancements
 
-- Refactor the mermaid diagram generation. Change `screenshot.py` -> `diagram.py` and added test coverage
-- Enable slicing and iterating of certain socket types (Vector, Color, etc.). ([#48](https://github.com/BradyAJohnston/nodebpy/pull/48))
+- Refactor the mermaid diagram generation. Change `screenshot.py` -> `diagram.py` and added test coverage.
+- **Socket iteration and indexing** — `VectorSocket`, `ColorSocket`, and `MatrixSocket` now support `__getitem__`, `__iter__`, and `__len__` on both output and input sockets. ([#48](https://github.com/BradyAJohnston/nodebpy/pull/48)) Output sockets decompose via `SeparateXYZ`/`SeparateColor`/`SeparateMatrix` (node reuse on repeated access); input sockets auto-wire a `CombineXYZ`/`CombineColor`/`CombineMatrix` and return the component input socket.
 ```python
 for i, axis in enumerate(g.Position().o.position):
     math = axis * float(i)
 
-mat = g.InstanceTransform().o.transform
+# Pipe a value into the Y component of a position input
+g.Value(5.0) >> g.SetPosition().i.position[1]
 
+mat = g.InstanceTransform().o.transform
 vec = g.CombineXYZ(*mat[:3])
 ```
-- **Socket iteration and indexing** — `VectorSocket`, `ColorSocket`, and `MatrixSocket` now support `__getitem__`, `__iter__`, and `__len__`. Output sockets decompose via `SeparateXYZ`/`SeparateColor`/`SeparateMatrix` (node reuse on repeated access); input sockets auto-wire a `CombineXYZ`/`CombineColor`/`CombineMatrix` and return the component input. Enables patterns like `for axis in vec_socket` and `value >> node.i.position[1]`.
 - **`RotationSocket`/`MatrixSocket` helpers** — Added `.invert` and `.transpose` properties on `MatrixSocket`, `.invert` on `RotationSocket`, following the same node-reuse pattern as `.x`/`.y`/`.z`.
 - **`SocketAccessor` overloads** — `__getitem__` and `_get` are overloaded so slices return `list[Socket]` and str/int keys return `Socket`, eliminating the `Socket | list[Socket]` union that was blocking `enumerate` and unpacking.
-- **Blender 5.1 compatibility** — Generator updated for Blender 5.1: `FontSocket` type, `Frame` node moved to `manually_defined`, `SVD` class name normalisation, and classmethod param deduplication fix (`min_x`/`min_y`/`min_z` no longer collapsed to `min`).
+- **Blender 5.1 compatibility** — Generator updated for Blender 5.1: `FontSocket` type, `Frame` node moved to `manually_defined`, `SVD` class name normalisation, and classmethod param deduplication fix (`min_x`/`min_y`/`min_z` no longer collapsed to `min`). ([#50](https://github.com/BradyAJohnston/nodebpy/pull/50))
+- **Precise operator return types** — Arithmetic operators on `FloatSocket` → `Math`, `VectorSocket` → `VectorMath`, `IntegerSocket` → `IntegerMath`. Comparison operators (`<`, `>`, `<=`, `>=`, `==`, `!=`) → `Compare`. The `>>` operator is typed via `TypeVar` so the right-hand operand's exact type is preserved through chains.
+- **Generic factory nodes** — `AccumulateField`, `EvaluateAtIndex`, `FieldAverage`, `FieldMinAndMax`, `EvaluateOnDomain`, `FieldVariance`, and `Compare` are now `Generic[_T]`. Their `_Inputs`/`_Outputs` inner classes carry the type parameter so e.g. `.point.vector(...)` returns `FieldAverage[VectorSocket]` and `.o.mean` resolves to `VectorSocket`.
 
 ### Bug Fixes
-- **Generic factory nodes** — `AccumulateField`, `EvaluateAtIndex`, `FieldAverage`, `FieldMinAndMax`, `EvaluateOnDomain`, `FieldVariance`, and `Compare` are now `Generic[_T]`. Their `_Inputs`/`_Outputs` inner classes carry the type parameter so `.point.vector(...)` returns `FieldAverage[VectorSocket]` and `.o.mean` resolves to `VectorSocket`.
-- **Precise operator return types** — Arithmetic operators on `FloatSocket` → `Math`, `VectorSocket` → `VectorMath`, `IntegerSocket` → `IntegerMath`. Comparison operators (`<`, `>`, `<=`, `>=`, `==`, `!=`) → `Compare`. The `>>` operator is now typed via `TypeVar` so the right-hand operand's exact type is preserved through chains.
-- Fix doc building and will only deploy on tagged releases([#49](https://github.com/BradyAJohnston/nodebpy/pull/49))
-- **Domain factory pattern** — All `_domain_factory` / local-class patterns replaced with proper `_DomainFactory` inner classes (including `CaptureAttribute`) so the type checker can see their return types.
+
+- Fix doc building and will only deploy on tagged releases. ([#49](https://github.com/BradyAJohnston/nodebpy/pull/49))
+- **Domain factory pattern** — All `_domain_factory` / local-class patterns replaced with proper `_DomainFactory` inner classes (including `CaptureAttribute`) so the type checker can resolve their return types.
 - **`SocketAccessor` identifier lookup fix** — Added a normalised-identifier pass (`normalize_name(id)`) so attribute access like `.i.value_001` correctly resolves Blender identifiers such as `Value_001` that cannot be round-tripped through `denormalize_name`.
 
 ## v0.10.2 - 2026-04-21

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nodebpy"
-version = "0.11.0"
+version = "0.11.1"
 description = "Build nodes trees in Blender more elegantly with code"
 readme = "README.md"
 authors = [

--- a/src/nodebpy/builder/mixins.py
+++ b/src/nodebpy/builder/mixins.py
@@ -276,7 +276,7 @@ class LinkingMixin:
         else:
             self._link(source, input)
 
-    def __rshift__(self, other: "BaseNode | Socket") -> "BaseNode | Socket":
+    def __rshift__(self, other: _RShiftT) -> _RShiftT:
         """Chain nodes using >> operator. Links output to input.
 
         Usage:


### PR DESCRIPTION
Return name / type is now properly propagated out of `>>` which was previously just generic `BaseNode | Socket`.
