### PR TITLE
Support custom node groups for each tree type

### DIFF
--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,1 +1,1 @@
-version: 0.11.0
+version: 0.11.1

--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,1 +1,1 @@
-version: 0.11.1
+version: 0.12.0

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,7 +2,12 @@
 title: Changelog
 ---
 
-## v0.11.1
+## v0.12.0 - 2026-04-25
+
+### Enhancements
+- Support custom node groups for each node tree via `CustomGeometryGroup`, `CustomShaderGroup`, `CustomCompositorGroup` ([`#53`](https://github.com/BradyAJohnston/nodebpy/issues/53))
+
+## v0.11.1 - 2026-04-24
 
 ### Bug Fixes
 - Fix type inference for the `>>` operator in chains, properly propagating the correct node's return type.

--- a/docs/custom-node-groups.qmd
+++ b/docs/custom-node-groups.qmd
@@ -3,7 +3,7 @@ title: Custom Node Groups
 ---
 
 ```{python}
-from nodebpy import GeometryNodeGroup, geometry as g
+from nodebpy import CustomGeometryGroup, geometry as g
 from nodebpy.types import (
     InputFloat,
     InputInteger,
@@ -27,7 +27,7 @@ A custom node group class has four parts:
 ```{python}
 # | eval: false
 
-class MyNode(GeometryNodeGroup):
+class MyNode(CustomGeometryGroup):
     _name = "My Node"  # 1. Name
 
     def __init__(self, value: float = 0.0):  # 3. Constructor
@@ -45,7 +45,7 @@ The display name for the group inside Blender. This is also the key used to cach
 Let's start with something visually obvious -- a node that randomly displaces each point on a mesh. This is useful any time you want to add organic variation to geometry.
 
 ```{python}
-class Jitter(GeometryNodeGroup):
+class Jitter(CustomGeometryGroup):
     """Randomly offset each point by a bounded amount."""
 
     _name = "Jitter"
@@ -98,7 +98,7 @@ Next, a node that distributes instances in a ring. This is a common pattern for 
 from math import tau
 
 
-class RadialArray(GeometryNodeGroup):
+class RadialArray(CustomGeometryGroup):
     """Distribute instances evenly around a circle."""
 
     _name = "Radial Array"

--- a/docs/custom-node-groups.qmd
+++ b/docs/custom-node-groups.qmd
@@ -3,7 +3,7 @@ title: Custom Node Groups
 ---
 
 ```{python}
-from nodebpy import NodeGroupBuilder, geometry as g
+from nodebpy import GeometryNodeGroup, geometry as g
 from nodebpy.types import (
     InputFloat,
     InputInteger,
@@ -27,14 +27,13 @@ A custom node group class has four parts:
 ```{python}
 # | eval: false
 
-class MyNode(NodeGroupBuilder):
+class MyNode(GeometryNodeGroup):
     _name = "My Node"  # 1. Name
 
     def __init__(self, value: float = 0.0):  # 3. Constructor
         super().__init__(value=value)
 
-    @classmethod
-    def _build_group(cls, tree):  # 4. Graph logic
+    def _build_group(self, tree):  # 4. Graph logic
         return (value + g.Value(1.0)) >> tree.ouptuts.float()
 ```
 
@@ -46,7 +45,7 @@ The display name for the group inside Blender. This is also the key used to cach
 Let's start with something visually obvious -- a node that randomly displaces each point on a mesh. This is useful any time you want to add organic variation to geometry.
 
 ```{python}
-class Jitter(NodeGroupBuilder):
+class Jitter(GeometryNodeGroup):
     """Randomly offset each point by a bounded amount."""
 
     _name = "Jitter"
@@ -60,8 +59,7 @@ class Jitter(NodeGroupBuilder):
     ):
         super().__init__(**{"Geometry": geometry, "Amount": amount, "Seed": seed})
 
-    @classmethod
-    def _build_group(cls, tree):
+    def _build_group(self, tree):
         geometry = tree.inputs.geometry("Geometry")
         amount = tree.inputs.float("Amount", 0.2)
         seed = tree.inputs.integer("Seed")
@@ -100,7 +98,7 @@ Next, a node that distributes instances in a ring. This is a common pattern for 
 from math import tau
 
 
-class RadialArray(NodeGroupBuilder):
+class RadialArray(GeometryNodeGroup):
     """Distribute instances evenly around a circle."""
 
     _name = "Radial Array"
@@ -114,8 +112,7 @@ class RadialArray(NodeGroupBuilder):
     ):
         super().__init__(geometry=geometry, count=count, radius=radius)
 
-    @classmethod
-    def _build_group(cls, tree):
+    def _build_group(self, tree):
         geometry = tree.inputs.geometry()
         count = tree.inputs.integer("Count", 6)
         radius = tree.inputs.float("Radius", 2.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nodebpy"
-version = "0.11.1"
+version = "0.12.0"
 description = "Build nodes trees in Blender more elegantly with code"
 readme = "README.md"
 authors = [

--- a/src/nodebpy/__init__.py
+++ b/src/nodebpy/__init__.py
@@ -1,10 +1,10 @@
-from . import nodes, diagram, sockets
+from . import diagram, nodes, sockets
 from .builder import (
-    TreeBuilder,
+    CustomCompositorGroup,
+    CustomGeometryGroup,
+    CustomShaderGroup,
     NodeGroupBuilder,
-    GeometryNodeGroup,
-    ShaderNodeGroup,
-    CompositorNodeGroup,
+    TreeBuilder,
 )
 from .nodes import compositor, geometry, shader
 

--- a/src/nodebpy/__init__.py
+++ b/src/nodebpy/__init__.py
@@ -1,5 +1,11 @@
 from . import nodes, diagram, sockets
-from .builder import TreeBuilder, NodeGroupBuilder
+from .builder import (
+    TreeBuilder,
+    NodeGroupBuilder,
+    GeometryNodeGroup,
+    ShaderNodeGroup,
+    CompositorNodeGroup,
+)
 from .nodes import compositor, geometry, shader
 
 __all__ = [
@@ -11,4 +17,7 @@ __all__ = [
     "diagram",
     "TreeBuilder",
     "NodeGroupBuilder",
+    "GeometryNodeGroup",
+    "ShaderNodeGroup",
+    "CompositorNodeGroup",
 ]

--- a/src/nodebpy/builder/__init__.py
+++ b/src/nodebpy/builder/__init__.py
@@ -27,7 +27,14 @@ from .interface import (
     SocketVector,
 )
 from .mixins import LinkingMixin, OperatorMixin
-from .node import BaseNode, DynamicInputsMixin, NodeGroupBuilder
+from .node import (
+    BaseNode,
+    CompositorNodeGroup,
+    DynamicInputsMixin,
+    GeometryNodeGroup,
+    NodeGroupBuilder,
+    ShaderNodeGroup,
+)
 from .socket import (
     BooleanSocket,
     BundleSocket,
@@ -82,6 +89,9 @@ __all__ = [
     "DynamicInputsMixin",
     # Node groups
     "NodeGroupBuilder",
+    "GeometryNodeGroup",
+    "ShaderNodeGroup",
+    "CompositorNodeGroup",
     # Type-specific socket classes (runtime)
     "FloatSocket",
     "VectorSocket",

--- a/src/nodebpy/builder/__init__.py
+++ b/src/nodebpy/builder/__init__.py
@@ -29,11 +29,11 @@ from .interface import (
 from .mixins import LinkingMixin, OperatorMixin
 from .node import (
     BaseNode,
-    CompositorNodeGroup,
+    CustomCompositorGroup,
+    CustomGeometryGroup,
+    CustomShaderGroup,
     DynamicInputsMixin,
-    GeometryNodeGroup,
     NodeGroupBuilder,
-    ShaderNodeGroup,
 )
 from .socket import (
     BooleanSocket,

--- a/src/nodebpy/builder/_utils.py
+++ b/src/nodebpy/builder/_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import bpy
 from bpy.types import NodeSocket
@@ -73,9 +73,15 @@ def _resolve_promotion(
     return self_socket, other, reverse
 
 
-class _NodeLike:
-    """Marker base for objects that wrap a Blender node (have .node, .inputs, .outputs)."""
+@runtime_checkable
+class _NodeLike(Protocol):
+    """Protocol for objects that wrap a Blender node and expose an ``outputs`` accessor."""
+
+    outputs: Any  # SocketAccessor at runtime; typed as Any to avoid circular import
 
 
-class _SocketLike:
-    """Marker base for objects that wrap a single Blender NodeSocket (have .socket)."""
+@runtime_checkable
+class _SocketLike(Protocol):
+    """Protocol for objects that wrap a single Blender NodeSocket and expose ``.socket``."""
+
+    socket: NodeSocket

--- a/src/nodebpy/builder/node.py
+++ b/src/nodebpy/builder/node.py
@@ -180,7 +180,7 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
         return SocketAccessor(self.node.inputs, "input")
 
 
-class DynamicInputsMixin:
+class DynamicInputsMixin(ABC):
     _socket_data_types: tuple[str, ...]
     _type_map: dict[str, str] = {}
 
@@ -211,8 +211,8 @@ class DynamicInputsMixin:
             target_name, source_socket = list(dyn._add_inputs(source).items())[0]
             return (source_socket, dyn.inputs[target_name].socket)
 
-    def _add_socket(self, name: str, *args: Any, **kwargs: Any) -> NodeSocket:
-        raise NotImplementedError(f"{type(self).__name__} must implement _add_socket")
+    @abstractmethod
+    def _add_socket(self, name: str, *args: Any, **kwargs: Any) -> NodeSocket: ...
 
     def _add_inputs(self, *args, **kwargs) -> dict[str, NodeSocket]:
         """Dictionary with {new_socket.name: from_linkable} for link creation"""

--- a/src/nodebpy/builder/node.py
+++ b/src/nodebpy/builder/node.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Protocol, Self, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Iterable,
+    Literal,
+    Protocol,
+    Self,
+    TypeVar,
+    cast,
+)
 
 import bpy
 from bpy.types import (
@@ -17,6 +27,8 @@ from ._utils import SocketError, _NodeLike, _SocketLike
 from .accessor import SocketAccessor
 from .mixins import LinkingMixin, OperatorMixin
 from .tree import TreeBuilder
+
+_T = TypeVar("_T", bound=bpy.types.NodeTree)
 
 if TYPE_CHECKING:
 
@@ -113,8 +125,9 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
             node >> socket
             return node
 
-    def _set_input_default_value(self, input, value):
+    def _set_input_default_value(self, input: NodeSocket, value: Any) -> None:
         """Set the default value for an input socket, handling type conversions."""
+        assert hasattr(input, "default_value")
         if (
             hasattr(input, "type")
             and input.type == "VECTOR"
@@ -231,7 +244,7 @@ class DynamicInputsMixin(ABC):
         return new_sockets
 
 
-class NodeGroupBuilder(BaseNode, ABC):
+class NodeGroupBuilder(BaseNode, ABC, Generic[_T]):
     """Base class for custom node groups.
 
     Subclasses implement :meth:`_build_group` with the node-graph logic.
@@ -240,6 +253,20 @@ class NodeGroupBuilder(BaseNode, ABC):
     """
 
     _name: str
+    _warning_propagation: Literal["ALL", "ERRORS_AND_WARNINGS", "ERRORS", "NONE"] = (
+        "ALL"
+    )
+    _color_tag: Literal[
+        "NONE",
+        "ATTRIBUTE",
+        "COLOR",
+        "CONVERTER",
+        "GEOMETRY",
+        "INPUT",
+        "OUTPUT",
+        "TEXTURE",
+        "VECTOR",
+    ] = "NONE"
 
     def __init__(self, **kwargs):
         super().__init__()
@@ -262,25 +289,21 @@ class NodeGroupBuilder(BaseNode, ABC):
     def _build_group(self, tree: TreeBuilder) -> None:
         """Build the node group internals and interface."""
 
+    def _get_or_create_tree(self) -> _T:
+        existing = bpy.data.node_groups[self._name]
+        if existing.bl_idname == self.tree.tree.bl_idname:
+            return cast(_T, existing)
+        raise TypeError(
+            f"Node group '{self._name}' already exists as "
+            f"{type(existing).__name__}, not {self._bl_idname}. "
+            f"Use a unique _name for this group."
+        )
 
-class GeometryNodeGroup(NodeGroupBuilder):
+
+class CustomGeometryGroup(NodeGroupBuilder[GeometryNodeTree]):
     """Node group in a Geometry Nodes tree."""
 
     _bl_idname = "GeometryNodeGroup"
-    _warning_propagation: Literal["ALL", "ERRORS_AND_WARNINGS", "ERRORS", "NONE"] = (
-        "ALL"
-    )
-    _color_tag: Literal[
-        "NONE",
-        "ATTRIBUTE",
-        "COLOR",
-        "CONVERTER",
-        "GEOMETRY",
-        "INPUT",
-        "OUTPUT",
-        "TEXTURE",
-        "VECTOR",
-    ] = "NONE"
     node: bpy.types.GeometryNodeGroup
 
     def _setup_node_group(self) -> None:
@@ -288,22 +311,16 @@ class GeometryNodeGroup(NodeGroupBuilder):
         self.node.warning_propagation = self._warning_propagation
 
     def _get_or_create_group(self) -> GeometryNodeTree:
-        if self._name in bpy.data.node_groups:
-            existing = bpy.data.node_groups[self._name]
-            if isinstance(existing, GeometryNodeTree):
-                return existing
-            raise TypeError(
-                f"Node group '{self._name}' already exists as "
-                f"{type(existing).__name__}, not GeometryNodeTree. "
-                f"Use a unique _name for this group."
-            )
-        with TreeBuilder.geometry(self._name) as tree:
-            self._build_group(tree)
-        tree.tree.color_tag = self._color_tag
-        return tree.tree
+        try:
+            return self._get_or_create_tree()
+        except KeyError:
+            with TreeBuilder.geometry(self._name) as tree:
+                self._build_group(tree)
+            tree.tree.color_tag = self._color_tag
+            return tree.tree
 
 
-class ShaderNodeGroup(NodeGroupBuilder):
+class CustomShaderGroup(NodeGroupBuilder[ShaderNodeTree]):
     """Node group in a Shader (Material) node tree."""
 
     _bl_idname = "ShaderNodeGroup"
@@ -313,21 +330,16 @@ class ShaderNodeGroup(NodeGroupBuilder):
         self.node.node_tree = self._get_or_create_group()
 
     def _get_or_create_group(self) -> ShaderNodeTree:
-        if self._name in bpy.data.node_groups:
-            existing = bpy.data.node_groups[self._name]
-            if isinstance(existing, ShaderNodeTree):
-                return existing
-            raise TypeError(
-                f"Node group '{self._name}' already exists as "
-                f"{type(existing).__name__}, not ShaderNodeTree. "
-                f"Use a unique _name for this group."
-            )
-        with TreeBuilder.shader(self._name) as tree:
-            self._build_group(tree)
-        return tree.tree
+        try:
+            return self._get_or_create_tree()
+        except KeyError:
+            with TreeBuilder.shader(self._name) as tree:
+                self._build_group(tree)
+            tree.tree.color_tag = self._color_tag
+            return tree.tree
 
 
-class CompositorNodeGroup(NodeGroupBuilder):
+class CustomCompositorGroup(NodeGroupBuilder[CompositorNodeTree]):
     """Node group in a Compositor node tree."""
 
     _bl_idname = "CompositorNodeGroup"
@@ -337,15 +349,10 @@ class CompositorNodeGroup(NodeGroupBuilder):
         self.node.node_tree = self._get_or_create_group()
 
     def _get_or_create_group(self) -> CompositorNodeTree:
-        if self._name in bpy.data.node_groups:
-            existing = bpy.data.node_groups[self._name]
-            if isinstance(existing, CompositorNodeTree):
-                return existing
-            raise TypeError(
-                f"Node group '{self._name}' already exists as "
-                f"{type(existing).__name__}, not CompositorNodeTree. "
-                f"Use a unique _name for this group."
-            )
-        with TreeBuilder.compositor(self._name) as tree:
-            self._build_group(tree)
-        return tree.tree
+        try:
+            return self._get_or_create_tree()
+        except KeyError:
+            with TreeBuilder.compositor(self._name) as tree:
+                self._build_group(tree)
+            tree.tree.color_tag = self._color_tag
+            return tree.tree

--- a/src/nodebpy/builder/node.py
+++ b/src/nodebpy/builder/node.py
@@ -289,7 +289,14 @@ class GeometryNodeGroup(NodeGroupBuilder):
 
     def _get_or_create_group(self) -> GeometryNodeTree:
         if self._name in bpy.data.node_groups:
-            return cast(GeometryNodeTree, bpy.data.node_groups[self._name])
+            existing = bpy.data.node_groups[self._name]
+            if isinstance(existing, GeometryNodeTree):
+                return existing
+            raise TypeError(
+                f"Node group '{self._name}' already exists as "
+                f"{type(existing).__name__}, not GeometryNodeTree. "
+                f"Use a unique _name for this group."
+            )
         with TreeBuilder.geometry(self._name) as tree:
             self._build_group(tree)
         tree.tree.color_tag = self._color_tag
@@ -307,7 +314,14 @@ class ShaderNodeGroup(NodeGroupBuilder):
 
     def _get_or_create_group(self) -> ShaderNodeTree:
         if self._name in bpy.data.node_groups:
-            return cast(ShaderNodeTree, bpy.data.node_groups[self._name])
+            existing = bpy.data.node_groups[self._name]
+            if isinstance(existing, ShaderNodeTree):
+                return existing
+            raise TypeError(
+                f"Node group '{self._name}' already exists as "
+                f"{type(existing).__name__}, not ShaderNodeTree. "
+                f"Use a unique _name for this group."
+            )
         with TreeBuilder.shader(self._name) as tree:
             self._build_group(tree)
         return tree.tree
@@ -324,7 +338,14 @@ class CompositorNodeGroup(NodeGroupBuilder):
 
     def _get_or_create_group(self) -> CompositorNodeTree:
         if self._name in bpy.data.node_groups:
-            return cast(CompositorNodeTree, bpy.data.node_groups[self._name])
+            existing = bpy.data.node_groups[self._name]
+            if isinstance(existing, CompositorNodeTree):
+                return existing
+            raise TypeError(
+                f"Node group '{self._name}' already exists as "
+                f"{type(existing).__name__}, not CompositorNodeTree. "
+                f"Use a unique _name for this group."
+            )
         with TreeBuilder.compositor(self._name) as tree:
             self._build_group(tree)
         return tree.tree

--- a/src/nodebpy/builder/node.py
+++ b/src/nodebpy/builder/node.py
@@ -1,19 +1,32 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterable, Literal, Self
+from typing import TYPE_CHECKING, Any, Iterable, Literal, Protocol, Self, cast
 
 import bpy
-from bpy.types import Node, NodeSocket
+from bpy.types import (
+    CompositorNodeTree,
+    GeometryNodeTree,
+    Node,
+    NodeSocket,
+    ShaderNodeTree,
+)
 
-from ..types import SOCKET_COMPATIBILITY, SOCKET_TYPES, InputAny, InputLinkable
+from ..types import SOCKET_COMPATIBILITY, SOCKET_TYPES, InputAny
 from ._utils import SocketError, _NodeLike, _SocketLike
 from .accessor import SocketAccessor
 from .mixins import LinkingMixin, OperatorMixin
 from .tree import TreeBuilder
 
 if TYPE_CHECKING:
-    pass
+
+    class _DynamicTarget(Protocol):
+        """Structural type for a node that supports dynamic socket addition."""
+
+        def _add_inputs(self, *args: Any, **kwargs: Any) -> dict[str, NodeSocket]: ...
+
+        @property
+        def inputs(self) -> SocketAccessor: ...
 
 
 class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
@@ -86,7 +99,9 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
                     assert link.to_node
                     if link.to_node.bl_idname == cls._bl_idname:
                         return cls._from_node(link.to_node)
-            return cls(socket)
+            node = cls()
+            node.tree.link(socket, node.inputs._best_match(socket.type))
+            return node
         else:
             if socket.links:
                 for link in socket.links:
@@ -115,7 +130,7 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
             if value is None or (
                 "GridPrune" in self._bl_idname
                 and name == "Threshold"
-                and self.node.data_type == "BOOLEAN"
+                and getattr(self.node, "data_type", None) == "BOOLEAN"
             ):
                 continue
             if isinstance(value, Node):
@@ -128,7 +143,7 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
                 continue
 
             elif isinstance(value, _SocketLike):
-                self._link_from(value, name)
+                self._link_from(value.socket, name)
             elif isinstance(value, NodeSocket):
                 self._link_from(value, name)
             elif isinstance(value, _NodeLike):
@@ -192,10 +207,14 @@ class DynamicInputsMixin:
         try:
             return super()._find_best_socket_pair(source, target)  # type: ignore
         except SocketError:
-            target_name, source_socket = list(target._add_inputs(source).items())[0]
-            return (source_socket, target.inputs[target_name].socket)
+            dyn = cast("_DynamicTarget", target)
+            target_name, source_socket = list(dyn._add_inputs(source).items())[0]
+            return (source_socket, dyn.inputs[target_name].socket)
 
-    def _add_inputs(self, *args, **kwargs) -> dict[str, InputLinkable]:
+    def _add_socket(self, name: str, *args: Any, **kwargs: Any) -> NodeSocket:
+        raise NotImplementedError(f"{type(self).__name__} must implement _add_socket")
+
+    def _add_inputs(self, *args, **kwargs) -> dict[str, NodeSocket]:
         """Dictionary with {new_socket.name: from_linkable} for link creation"""
         new_sockets = {}
         items = {}
@@ -216,9 +235,37 @@ class NodeGroupBuilder(BaseNode, ABC):
     """Base class for custom node groups.
 
     Subclasses implement :meth:`_build_group` with the node-graph logic.
+    Subclass one of the editor-specific variants: :class:`GeometryNodeGroup`,
+    :class:`ShaderNodeGroup`, or :class:`CompositorNodeGroup`.
     """
 
     _name: str
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self._setup_node_group()
+        self.node.show_options = False
+        self._establish_links(**kwargs)
+
+    @abstractmethod
+    def _setup_node_group(self) -> None:
+        """Set ``self.node.node_tree`` and any node-type-specific properties.
+
+        Called by ``__init__`` after the node is created but before links are
+        established. Concrete subclasses have a narrowed ``self.node`` type,
+        so the ``node_tree`` assignment is type-safe here rather than in the
+        base class where ``self.node`` is only ``bpy.types.Node``.
+        """
+        ...
+
+    @abstractmethod
+    def _build_group(self, tree: TreeBuilder) -> None:
+        """Build the node group internals and interface."""
+
+
+class GeometryNodeGroup(NodeGroupBuilder):
+    """Node group in a Geometry Nodes tree."""
+
     _bl_idname = "GeometryNodeGroup"
     _warning_propagation: Literal["ALL", "ERRORS_AND_WARNINGS", "ERRORS", "NONE"] = (
         "ALL"
@@ -236,25 +283,48 @@ class NodeGroupBuilder(BaseNode, ABC):
     ] = "NONE"
     node: bpy.types.GeometryNodeGroup
 
-    def __init__(self, **kwargs):
-        super().__init__()
+    def _setup_node_group(self) -> None:
         self.node.node_tree = self._get_or_create_group()
-        self.node.show_options = False
         self.node.warning_propagation = self._warning_propagation
-        self._establish_links(**kwargs)
 
-    def _get_or_create_group(self) -> bpy.types.GeometryNodeTree:
-        name = self._name
-        if name in bpy.data.node_groups:
-            return bpy.data.node_groups[name]
-
-        with TreeBuilder(name) as tree:
+    def _get_or_create_group(self) -> GeometryNodeTree:
+        if self._name in bpy.data.node_groups:
+            return cast(GeometryNodeTree, bpy.data.node_groups[self._name])
+        with TreeBuilder.geometry(self._name) as tree:
             self._build_group(tree)
-            tree.tree.color_tag = self._color_tag
-
+        tree.tree.color_tag = self._color_tag
         return tree.tree
 
-    @classmethod
-    @abstractmethod
-    def _build_group(cls, tree: TreeBuilder) -> None:
-        """Code that builds the node group internals and interface"""
+
+class ShaderNodeGroup(NodeGroupBuilder):
+    """Node group in a Shader (Material) node tree."""
+
+    _bl_idname = "ShaderNodeGroup"
+    node: bpy.types.ShaderNodeGroup
+
+    def _setup_node_group(self) -> None:
+        self.node.node_tree = self._get_or_create_group()
+
+    def _get_or_create_group(self) -> ShaderNodeTree:
+        if self._name in bpy.data.node_groups:
+            return cast(ShaderNodeTree, bpy.data.node_groups[self._name])
+        with TreeBuilder.shader(self._name) as tree:
+            self._build_group(tree)
+        return tree.tree
+
+
+class CompositorNodeGroup(NodeGroupBuilder):
+    """Node group in a Compositor node tree."""
+
+    _bl_idname = "CompositorNodeGroup"
+    node: bpy.types.CompositorNodeGroup
+
+    def _setup_node_group(self) -> None:
+        self.node.node_tree = self._get_or_create_group()
+
+    def _get_or_create_group(self) -> CompositorNodeTree:
+        if self._name in bpy.data.node_groups:
+            return cast(CompositorNodeTree, bpy.data.node_groups[self._name])
+        with TreeBuilder.compositor(self._name) as tree:
+            self._build_group(tree)
+        return tree.tree

--- a/src/nodebpy/builder/tree.py
+++ b/src/nodebpy/builder/tree.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, Self, TypeVar, cast
 
 import bpy
 from bpy.types import (
@@ -623,12 +623,16 @@ class OutputInterfaceContext(DirectionalContext):
     _direction = "OUTPUT"
 
 
-class TreeBuilder:
+_TreeT = TypeVar("_TreeT", bound=NodeTree)
+
+
+class TreeBuilder(Generic[_TreeT]):
     """Builder for creating Blender node trees with a clean Python API.
 
     Supports geometry, shader, and compositor node trees.
     """
 
+    tree: _TreeT
     _tree_contexts: ClassVar["list[TreeBuilder]"] = []
     _frame_contexts: ClassVar["list[NodeFrame]"] = []
 
@@ -645,9 +649,9 @@ class TreeBuilder:
         ignore_visibility: bool = False,
     ):
         if isinstance(tree, str):
-            self.tree = bpy.data.node_groups.new(tree, tree_type)
+            self.tree = bpy.data.node_groups.new(tree, tree_type)  # type: ignore[assignment]
         else:
-            self.tree = tree
+            self.tree = tree  # type: ignore[assignment]
 
         self._menu_defaults: dict[str, str] = {}
         self.inputs = InputInterfaceContext(self)
@@ -665,14 +669,17 @@ class TreeBuilder:
         collapse: bool = False,
         arrange: Literal["sugiyama", "simple"] | None = "sugiyama",
         fake_user: bool = False,
-    ) -> "TreeBuilder":
+    ) -> "TreeBuilder[GeometryNodeTree]":
         """Create a geometry node tree."""
-        return cls(
-            name,
-            tree_type="GeometryNodeTree",
-            collapse=collapse,
-            arrange=arrange,
-            fake_user=fake_user,
+        return cast(
+            "TreeBuilder[GeometryNodeTree]",
+            cls(
+                name,
+                tree_type="GeometryNodeTree",
+                collapse=collapse,
+                arrange=arrange,
+                fake_user=fake_user,
+            ),
         )
 
     @classmethod
@@ -683,14 +690,17 @@ class TreeBuilder:
         collapse: bool = False,
         arrange: Literal["sugiyama", "simple"] | None = "sugiyama",
         fake_user: bool = False,
-    ) -> "TreeBuilder":
+    ) -> "TreeBuilder[ShaderNodeTree]":
         """Create a shader node tree."""
-        return cls(
-            name,
-            tree_type="ShaderNodeTree",
-            collapse=collapse,
-            arrange=arrange,
-            fake_user=fake_user,
+        return cast(
+            "TreeBuilder[ShaderNodeTree]",
+            cls(
+                name,
+                tree_type="ShaderNodeTree",
+                collapse=collapse,
+                arrange=arrange,
+                fake_user=fake_user,
+            ),
         )
 
     @classmethod
@@ -701,14 +711,17 @@ class TreeBuilder:
         collapse: bool = False,
         arrange: Literal["sugiyama", "simple"] | None = "sugiyama",
         fake_user: bool = False,
-    ) -> "TreeBuilder":
+    ) -> "TreeBuilder[CompositorNodeTree]":
         """Create a compositor node tree."""
-        return cls(
-            name,
-            tree_type="CompositorNodeTree",
-            collapse=collapse,
-            arrange=arrange,
-            fake_user=fake_user,
+        return cast(
+            "TreeBuilder[CompositorNodeTree]",
+            cls(
+                name,
+                tree_type="CompositorNodeTree",
+                collapse=collapse,
+                arrange=arrange,
+                fake_user=fake_user,
+            ),
         )
 
     @property

--- a/src/nodebpy/nodes/geometry/groups.py
+++ b/src/nodebpy/nodes/geometry/groups.py
@@ -5,7 +5,7 @@ from nodebpy.nodes.compositor import CombineXYZ
 from nodebpy.types import InputInteger, InputVector
 
 from ...builder import (
-    GeometryNodeGroup,
+    CustomGeometryGroup,
     IntegerSocket,
     RotationSocket,
     SocketAccessor,
@@ -25,7 +25,7 @@ from . import (
 )
 
 
-class OtherVertex(GeometryNodeGroup):
+class OtherVertex(CustomGeometryGroup):
     """
     Given a vertex and an edge number from that vertex, returns the other
     vertex of that edge.
@@ -71,7 +71,7 @@ class OtherVertex(GeometryNodeGroup):
         _ = switch >> tree.outputs.integer("Other Vertex")
 
 
-class OffsetVector(GeometryNodeGroup):
+class OffsetVector(CustomGeometryGroup):
     """
     Evaluate a given vector field at an offset to the current ``Index``.
     """
@@ -117,7 +117,7 @@ class OffsetVector(GeometryNodeGroup):
         _ = value >> tree.outputs.vector("Vector")
 
 
-class PrincipalComponents(GeometryNodeGroup):
+class PrincipalComponents(CustomGeometryGroup):
     """
     Compute PCA on a given vector field.
     """

--- a/src/nodebpy/nodes/geometry/groups.py
+++ b/src/nodebpy/nodes/geometry/groups.py
@@ -5,8 +5,8 @@ from nodebpy.nodes.compositor import CombineXYZ
 from nodebpy.types import InputInteger, InputVector
 
 from ...builder import (
+    GeometryNodeGroup,
     IntegerSocket,
-    NodeGroupBuilder,
     RotationSocket,
     SocketAccessor,
     VectorSocket,
@@ -25,7 +25,7 @@ from . import (
 )
 
 
-class OtherVertex(NodeGroupBuilder):
+class OtherVertex(GeometryNodeGroup):
     """
     Given a vertex and an edge number from that vertex, returns the other
     vertex of that edge.
@@ -58,8 +58,7 @@ class OtherVertex(NodeGroupBuilder):
         kwargs = {"Vertex Index": vertex_index, "Edge Number": edge_number}
         super().__init__(**kwargs)
 
-    @classmethod
-    def _build_group(cls, tree):
+    def _build_group(self, tree: TreeBuilder):
         vertex_index = tree.inputs.integer("Vertex Index", default_input="INDEX")
         edge_number = tree.inputs.integer("Edge Number")
 
@@ -72,7 +71,7 @@ class OtherVertex(NodeGroupBuilder):
         _ = switch >> tree.outputs.integer("Other Vertex")
 
 
-class OffsetVector(NodeGroupBuilder):
+class OffsetVector(GeometryNodeGroup):
     """
     Evaluate a given vector field at an offset to the current ``Index``.
     """
@@ -108,8 +107,7 @@ class OffsetVector(NodeGroupBuilder):
     ):
         super().__init__(index=index, vector=vector, offset=offset)
 
-    @classmethod
-    def _build_group(cls, tree):
+    def _build_group(self, tree: TreeBuilder):
         index = tree.inputs.integer("Index", default_input="INDEX")
         vector = tree.inputs.vector("Vector", default_input="POSITION")
         offset = tree.inputs.integer("Offset")
@@ -119,7 +117,7 @@ class OffsetVector(NodeGroupBuilder):
         _ = value >> tree.outputs.vector("Vector")
 
 
-class PrincipalComponents(NodeGroupBuilder):
+class PrincipalComponents(GeometryNodeGroup):
     """
     Compute PCA on a given vector field.
     """

--- a/tests/test_custom_groups.py
+++ b/tests/test_custom_groups.py
@@ -22,7 +22,7 @@ class _SimpleGeomGroup(GeometryNodeGroup):
     _color_tag = "GEOMETRY"
     _warning_propagation = "ERRORS"
 
-    def _build_group(self, tree):
+    def _build_group(self, tree: TreeBuilder[GeometryNodeTree]):
         x = tree.inputs.float("Value")
         x >> tree.outputs.float("Result")
 
@@ -318,15 +318,3 @@ def test_group_already_exists_wrong_type():
     with c.tree():
         with pytest.raises(TypeError):
             _CompGroup()
-
-
-def test_dynamic_inputs_mixin():
-    class _DynamicGroup(GeometryNodeGroup, DynamicInputsMixin):
-        _name = "Test Dynamic Group"
-
-        def _build_group(self, tree):
-            pass
-
-    with TreeBuilder():
-        with pytest.raises(NotImplementedError):
-            _DynamicGroup()._add_socket("test")

--- a/tests/test_custom_groups.py
+++ b/tests/test_custom_groups.py
@@ -6,9 +6,11 @@ from bpy.types import CompositorNodeTree, GeometryNodeTree, ShaderNodeTree
 
 from nodebpy import CompositorNodeGroup, GeometryNodeGroup, ShaderNodeGroup, TreeBuilder
 from nodebpy.builder import SocketLinker
+from nodebpy.builder.node import DynamicInputsMixin
+from nodebpy.nodes import compositor as c
+from nodebpy.nodes import geometry as g
 from nodebpy.nodes.geometry import IntegerMath
 from nodebpy.nodes.geometry.groups import OffsetVector, OtherVertex
-
 
 # ---------------------------------------------------------------------------
 # Concrete subclasses used in the new tests below
@@ -193,11 +195,15 @@ def test_type_mismatch_geometry_vs_shader_raises():
 
     class _ConflictGeom(GeometryNodeGroup):
         _name = "Test Conflict Geom vs Shader"
-        def _build_group(self, tree): pass
+
+        def _build_group(self, tree):
+            pass
 
     class _ConflictShader(ShaderNodeGroup):
         _name = "Test Conflict Geom vs Shader"
-        def _build_group(self, tree): pass
+
+        def _build_group(self, tree):
+            pass
 
     with TreeBuilder():
         _ConflictGeom()
@@ -212,11 +218,15 @@ def test_type_mismatch_shader_vs_compositor_raises():
 
     class _ConflictShader(ShaderNodeGroup):
         _name = "Test Conflict Shader vs Compositor"
-        def _build_group(self, tree): pass
+
+        def _build_group(self, tree):
+            pass
 
     class _ConflictCompositor(CompositorNodeGroup):
         _name = "Test Conflict Shader vs Compositor"
-        def _build_group(self, tree): pass
+
+        def _build_group(self, tree):
+            pass
 
     with TreeBuilder.shader():
         _ConflictShader()
@@ -231,11 +241,15 @@ def test_same_name_same_type_does_not_raise():
 
     class _CacheA(GeometryNodeGroup):
         _name = "Test Same Type Cache"
-        def _build_group(self, tree): pass
+
+        def _build_group(self, tree):
+            pass
 
     class _CacheB(GeometryNodeGroup):
         _name = "Test Same Type Cache"
-        def _build_group(self, tree): pass
+
+        def _build_group(self, tree):
+            pass
 
     with TreeBuilder():
         a = _CacheA()
@@ -283,3 +297,36 @@ def test_build_group_called_once_across_instances():
         _CountCalls()
 
     assert call_count[0] == 1
+
+
+def test_group_already_exists_wrong_type():
+    class _GeomGroup(GeometryNodeGroup):
+        _name = "TestGroup"
+
+        def _build_group(self, tree):
+            pass
+
+    class _CompGroup(CompositorNodeGroup):
+        _name = "TestGroup"
+
+        def _build_group(self, tree):
+            pass
+
+    with g.tree():
+        _GeomGroup()
+
+    with c.tree():
+        with pytest.raises(TypeError):
+            _CompGroup()
+
+
+def test_dynamic_inputs_mixin():
+    class _DynamicGroup(GeometryNodeGroup, DynamicInputsMixin):
+        _name = "Test Dynamic Group"
+
+        def _build_group(self, tree):
+            pass
+
+    with TreeBuilder():
+        with pytest.raises(NotImplementedError):
+            _DynamicGroup()._add_socket("test")

--- a/tests/test_custom_groups.py
+++ b/tests/test_custom_groups.py
@@ -4,7 +4,12 @@ import bpy
 import pytest
 from bpy.types import CompositorNodeTree, GeometryNodeTree, ShaderNodeTree
 
-from nodebpy import CompositorNodeGroup, GeometryNodeGroup, ShaderNodeGroup, TreeBuilder
+from nodebpy import (
+    CustomCompositorGroup,
+    CustomGeometryGroup,
+    CustomShaderGroup,
+    TreeBuilder,
+)
 from nodebpy.builder import SocketLinker
 from nodebpy.builder.node import DynamicInputsMixin
 from nodebpy.nodes import compositor as c
@@ -17,7 +22,7 @@ from nodebpy.nodes.geometry.groups import OffsetVector, OtherVertex
 # ---------------------------------------------------------------------------
 
 
-class _SimpleGeomGroup(GeometryNodeGroup):
+class _SimpleGeomGroup(CustomGeometryGroup):
     _name = "Test Simple Geometry Group"
     _color_tag = "GEOMETRY"
     _warning_propagation = "ERRORS"
@@ -27,7 +32,7 @@ class _SimpleGeomGroup(GeometryNodeGroup):
         x >> tree.outputs.float("Result")
 
 
-class _SimpleShaderGroup(ShaderNodeGroup):
+class _SimpleShaderGroup(CustomShaderGroup):
     _name = "Test Simple Shader Group"
 
     def _build_group(self, tree):
@@ -35,7 +40,7 @@ class _SimpleShaderGroup(ShaderNodeGroup):
         x >> tree.outputs.float("Result")
 
 
-class _SimpleCompositorGroup(CompositorNodeGroup):
+class _SimpleCompositorGroup(CustomCompositorGroup):
     _name = "Test Simple Compositor Group"
 
     def _build_group(self, tree):
@@ -193,13 +198,13 @@ def test_geometry_node_group_warning_propagation():
 def test_type_mismatch_geometry_vs_shader_raises():
     """Reusing a geometry group name for a ShaderNodeGroup raises TypeError."""
 
-    class _ConflictGeom(GeometryNodeGroup):
+    class _ConflictGeom(CustomGeometryGroup):
         _name = "Test Conflict Geom vs Shader"
 
         def _build_group(self, tree):
             pass
 
-    class _ConflictShader(ShaderNodeGroup):
+    class _ConflictShader(CustomShaderGroup):
         _name = "Test Conflict Geom vs Shader"
 
         def _build_group(self, tree):
@@ -216,13 +221,13 @@ def test_type_mismatch_geometry_vs_shader_raises():
 def test_type_mismatch_shader_vs_compositor_raises():
     """Reusing a shader group name for a CompositorNodeGroup raises TypeError."""
 
-    class _ConflictShader(ShaderNodeGroup):
+    class _ConflictShader(CustomShaderGroup):
         _name = "Test Conflict Shader vs Compositor"
 
         def _build_group(self, tree):
             pass
 
-    class _ConflictCompositor(CompositorNodeGroup):
+    class _ConflictCompositor(CustomCompositorGroup):
         _name = "Test Conflict Shader vs Compositor"
 
         def _build_group(self, tree):
@@ -239,13 +244,13 @@ def test_type_mismatch_shader_vs_compositor_raises():
 def test_same_name_same_type_does_not_raise():
     """Reusing a name for the same tree type is fine — it returns the cached tree."""
 
-    class _CacheA(GeometryNodeGroup):
+    class _CacheA(CustomGeometryGroup):
         _name = "Test Same Type Cache"
 
         def _build_group(self, tree):
             pass
 
-    class _CacheB(GeometryNodeGroup):
+    class _CacheB(CustomGeometryGroup):
         _name = "Test Same Type Cache"
 
         def _build_group(self, tree):
@@ -267,7 +272,7 @@ def test_build_group_receives_instance_not_class():
     """_build_group receives self as a class instance, not the class itself."""
     captured = []
 
-    class _SelfCheck(GeometryNodeGroup):
+    class _SelfCheck(CustomGeometryGroup):
         _name = "Test Build Group Self Check"
 
         def _build_group(self, tree):
@@ -285,7 +290,7 @@ def test_build_group_called_once_across_instances():
     """_build_group is only called when the group is first created, not on reuse."""
     call_count = [0]
 
-    class _CountCalls(GeometryNodeGroup):
+    class _CountCalls(CustomGeometryGroup):
         _name = "Test Build Group Call Count"
 
         def _build_group(self, tree):
@@ -300,13 +305,13 @@ def test_build_group_called_once_across_instances():
 
 
 def test_group_already_exists_wrong_type():
-    class _GeomGroup(GeometryNodeGroup):
+    class _GeomGroup(CustomGeometryGroup):
         _name = "TestGroup"
 
         def _build_group(self, tree):
             pass
 
-    class _CompGroup(CompositorNodeGroup):
+    class _CompGroup(CustomCompositorGroup):
         _name = "TestGroup"
 
         def _build_group(self, tree):

--- a/tests/test_custom_groups.py
+++ b/tests/test_custom_groups.py
@@ -2,13 +2,43 @@ from functools import reduce
 
 import bpy
 import pytest
+from bpy.types import CompositorNodeTree, GeometryNodeTree, ShaderNodeTree
 
-from nodebpy import TreeBuilder
-from nodebpy.builder import (
-    SocketLinker,
-)
+from nodebpy import CompositorNodeGroup, GeometryNodeGroup, ShaderNodeGroup, TreeBuilder
+from nodebpy.builder import SocketLinker
 from nodebpy.nodes.geometry import IntegerMath
 from nodebpy.nodes.geometry.groups import OffsetVector, OtherVertex
+
+
+# ---------------------------------------------------------------------------
+# Concrete subclasses used in the new tests below
+# ---------------------------------------------------------------------------
+
+
+class _SimpleGeomGroup(GeometryNodeGroup):
+    _name = "Test Simple Geometry Group"
+    _color_tag = "GEOMETRY"
+    _warning_propagation = "ERRORS"
+
+    def _build_group(self, tree):
+        x = tree.inputs.float("Value")
+        x >> tree.outputs.float("Result")
+
+
+class _SimpleShaderGroup(ShaderNodeGroup):
+    _name = "Test Simple Shader Group"
+
+    def _build_group(self, tree):
+        x = tree.inputs.float("Value")
+        x >> tree.outputs.float("Result")
+
+
+class _SimpleCompositorGroup(CompositorNodeGroup):
+    _name = "Test Simple Compositor Group"
+
+    def _build_group(self, tree):
+        x = tree.inputs.float("Value")
+        x >> tree.outputs.float("Result")
 
 
 def test_custom_group():
@@ -83,3 +113,173 @@ def test_group_reuses_existing_node_group():
 
     assert a.node.node_tree is b.node.node_tree
     assert a.node is not b.node
+
+
+# ---------------------------------------------------------------------------
+# ShaderNodeGroup
+# ---------------------------------------------------------------------------
+
+
+def test_shader_node_group_creates_shader_tree():
+    """ShaderNodeGroup.node_tree is a ShaderNodeTree."""
+    with TreeBuilder.shader():
+        node = _SimpleShaderGroup()
+    assert isinstance(node.node.node_tree, ShaderNodeTree)
+
+
+def test_shader_node_group_reuses_tree():
+    """Multiple instances share the same underlying ShaderNodeTree."""
+    with TreeBuilder.shader():
+        a = _SimpleShaderGroup()
+        b = _SimpleShaderGroup()
+    assert a.node.node_tree is b.node.node_tree
+    assert a.node is not b.node
+
+
+# ---------------------------------------------------------------------------
+# CompositorNodeGroup
+# ---------------------------------------------------------------------------
+
+
+def test_compositor_node_group_creates_compositor_tree():
+    """CompositorNodeGroup.node_tree is a CompositorNodeTree."""
+    with TreeBuilder.compositor():
+        node = _SimpleCompositorGroup()
+    assert isinstance(node.node.node_tree, CompositorNodeTree)
+
+
+def test_compositor_node_group_reuses_tree():
+    """Multiple instances share the same underlying CompositorNodeTree."""
+    with TreeBuilder.compositor():
+        a = _SimpleCompositorGroup()
+        b = _SimpleCompositorGroup()
+    assert a.node.node_tree is b.node.node_tree
+    assert a.node is not b.node
+
+
+# ---------------------------------------------------------------------------
+# GeometryNodeGroup — class-level properties
+# ---------------------------------------------------------------------------
+
+
+def test_geometry_node_group_creates_geometry_tree():
+    """GeometryNodeGroup.node_tree is a GeometryNodeTree."""
+    with TreeBuilder():
+        node = _SimpleGeomGroup()
+    assert isinstance(node.node.node_tree, GeometryNodeTree)
+
+
+def test_geometry_node_group_color_tag():
+    """_color_tag is applied to the node tree on first creation."""
+    with TreeBuilder():
+        node = _SimpleGeomGroup()
+    assert node.node.node_tree.color_tag == "GEOMETRY"
+
+
+def test_geometry_node_group_warning_propagation():
+    """_warning_propagation is applied to the node instance."""
+    with TreeBuilder():
+        node = _SimpleGeomGroup()
+    assert node.node.warning_propagation == "ERRORS"
+
+
+# ---------------------------------------------------------------------------
+# Type-mismatch detection
+# ---------------------------------------------------------------------------
+
+
+def test_type_mismatch_geometry_vs_shader_raises():
+    """Reusing a geometry group name for a ShaderNodeGroup raises TypeError."""
+
+    class _ConflictGeom(GeometryNodeGroup):
+        _name = "Test Conflict Geom vs Shader"
+        def _build_group(self, tree): pass
+
+    class _ConflictShader(ShaderNodeGroup):
+        _name = "Test Conflict Geom vs Shader"
+        def _build_group(self, tree): pass
+
+    with TreeBuilder():
+        _ConflictGeom()
+
+    with TreeBuilder.shader():
+        with pytest.raises(TypeError, match="already exists"):
+            _ConflictShader()
+
+
+def test_type_mismatch_shader_vs_compositor_raises():
+    """Reusing a shader group name for a CompositorNodeGroup raises TypeError."""
+
+    class _ConflictShader(ShaderNodeGroup):
+        _name = "Test Conflict Shader vs Compositor"
+        def _build_group(self, tree): pass
+
+    class _ConflictCompositor(CompositorNodeGroup):
+        _name = "Test Conflict Shader vs Compositor"
+        def _build_group(self, tree): pass
+
+    with TreeBuilder.shader():
+        _ConflictShader()
+
+    with TreeBuilder.compositor():
+        with pytest.raises(TypeError, match="already exists"):
+            _ConflictCompositor()
+
+
+def test_same_name_same_type_does_not_raise():
+    """Reusing a name for the same tree type is fine — it returns the cached tree."""
+
+    class _CacheA(GeometryNodeGroup):
+        _name = "Test Same Type Cache"
+        def _build_group(self, tree): pass
+
+    class _CacheB(GeometryNodeGroup):
+        _name = "Test Same Type Cache"
+        def _build_group(self, tree): pass
+
+    with TreeBuilder():
+        a = _CacheA()
+        b = _CacheB()  # different Python class, same _name → reuses
+
+    assert a.node.node_tree is b.node.node_tree
+
+
+# ---------------------------------------------------------------------------
+# _build_group is a regular instance method (not classmethod)
+# ---------------------------------------------------------------------------
+
+
+def test_build_group_receives_instance_not_class():
+    """_build_group receives self as a class instance, not the class itself."""
+    captured = []
+
+    class _SelfCheck(GeometryNodeGroup):
+        _name = "Test Build Group Self Check"
+
+        def _build_group(self, tree):
+            captured.append(self)
+
+    with TreeBuilder():
+        node = _SelfCheck()
+
+    assert len(captured) == 1
+    assert isinstance(captured[0], _SelfCheck)
+    assert not isinstance(captured[0], type)
+
+
+def test_build_group_called_once_across_instances():
+    """_build_group is only called when the group is first created, not on reuse."""
+    call_count = [0]
+
+    class _CountCalls(GeometryNodeGroup):
+        _name = "Test Build Group Call Count"
+
+        def _build_group(self, tree):
+            call_count[0] += 1
+
+    with TreeBuilder():
+        _CountCalls()
+        _CountCalls()
+        _CountCalls()
+
+    assert call_count[0] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1169,7 +1169,7 @@ wheels = [
 
 [[package]]
 name = "nodebpy"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1169,7 +1169,7 @@ wheels = [
 
 [[package]]
 name = "nodebpy"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Can now subclass to create a custom node for each node tree. Fixes #52 

```py

class CustomNode(CustomGeometryGroup): ...

class AnotherNode(CustomCompositorGroup): ...

class YetAnotherNode(CustomShaderGroup): ...

```
