### PR TITLE
Fix math for color sockets

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## Unreleased
+
+### Bug Fixes
+- Math on a `ColorSocket` now uses the `VectorMath` instead of `Math` preserving the RGB channels as XYZ. ([`#56`](https://github.com/BradyAJohnston/nodebpy/pull/56))
+
 ## v0.12.0 - 2026-04-25
 
 ### Enhancements

--- a/src/nodebpy/builder/_utils.py
+++ b/src/nodebpy/builder/_utils.py
@@ -67,7 +67,10 @@ def _resolve_promotion(
 
     if other_prec > self_prec:
         # Other side is dominant — swap so the linker wraps the vector/higher socket
-        other_socket = other._default_output_socket
+        if isinstance(other, NodeSocket):
+            other_socket = other
+        else:
+            other_socket = other._default_output_socket
         return other_socket, self_socket, not reverse
 
     return self_socket, other, reverse

--- a/src/nodebpy/builder/accessor.py
+++ b/src/nodebpy/builder/accessor.py
@@ -28,7 +28,7 @@ class SocketAccessor:
 
     def __init__(
         self,
-        collection: bpy.types.NodeInputs | bpy.types.NodeOutputs,
+        collection: bpy.types.NodeInputs | bpy.types.NodeOutputs | list[NodeSocket],
         direction: Literal["input", "output"],
     ):
         self._direction = direction

--- a/src/nodebpy/builder/mixins.py
+++ b/src/nodebpy/builder/mixins.py
@@ -100,9 +100,12 @@ class OperatorMixin:
         )
 
     def _apply_compare_operation(self, other: Any, operation: str) -> "Math":
-        return _get_socket_linker(self._default_output_socket)._dispatch_compare(  # type: ignore[attr-defined]
-            other, operation
+        socket, other, _ = _resolve_promotion(
+            self._default_output_socket,  # type: ignore[attr-defined]
+            other,
+            False,
         )
+        return _get_socket_linker(socket)._dispatch_compare(other, operation)
 
     def __lt__(self, other: Any) -> "Compare":
         return self._apply_compare_operation(other, "less_than")

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -141,9 +141,12 @@ class Socket(_SocketLike, OperatorMixin, LinkingMixin):
                 "greater_than": ("greater_than", False),
                 "less_equal": ("greater_than", True),
                 "greater_equal": ("less_than", True),
+                "equal": ("compare", False),
             }
             math_op, negate = _MATH_COMPARE_MAP[operation]
             result = getattr(Math, math_op)(self.socket, other)
+            if operation == "equal":
+                result.i.value_002.default_value = 0.00001
             if negate:
                 result = Math.subtract(1.0, result._default_output_socket)
             return result
@@ -533,7 +536,7 @@ class _IntegerMixin:
             return IntegerMath.divide_floor(*values)
         return Socket._dispatch_floordiv(cast("Socket", self), other, reverse)
 
-    def _dispatch_compare(self, other: Any, operation: str) -> "BaseNode":
+    def _dispatch_compare(self, other: Any, operation: str) -> "Compare | Math":
         if isinstance(self._tree.tree, GeometryNodeTree):
             from ..nodes.geometry.manual import Compare
 

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterator, overload
+from typing import TYPE_CHECKING, Any, Iterator, cast, overload
 
 import bpy
 from bpy.types import (
@@ -25,6 +25,7 @@ from bpy.types import (
     NodeSocketShader,
     NodeSocketString,
     NodeSocketVector,
+    NodeTree,
 )
 from mathutils import Euler
 
@@ -55,7 +56,7 @@ class Socket(_SocketLike, OperatorMixin, LinkingMixin):
         self.socket = socket
         self.node = socket.node
         self._default_output_id = socket.identifier
-        self._tree = TreeBuilder(socket.node.id_data)  # type: ignore
+        self._tree = TreeBuilder(cast(NodeTree, socket.node.id_data))
 
     @property
     def tree(self) -> TreeBuilder:
@@ -167,8 +168,8 @@ class Socket(_SocketLike, OperatorMixin, LinkingMixin):
         def __gt__(self, other: Any) -> "Compare": ...
         def __le__(self, other: Any) -> "Compare": ...
         def __ge__(self, other: Any) -> "Compare": ...
-        def __eq__(self, other: Any) -> "Compare": ...  # type: ignore[override]
-        def __ne__(self, other: Any) -> "Compare": ...  # type: ignore[override]
+        def __eq__(self, other: Any) -> "Compare": ...
+        def __ne__(self, other: Any) -> "Compare": ...
 
 
 # ---------------------------------------------------------------------------
@@ -308,7 +309,7 @@ class _VectorMixin:
 
             return getattr(Compare.vector, operation)(self.socket, other)
         else:
-            return Socket._dispatch_compare(self, other, operation)  # type: ignore[arg-type]
+            return Socket._dispatch_compare(cast("Socket", self), other, operation)
 
     if TYPE_CHECKING:
 
@@ -324,12 +325,10 @@ class _VectorMixin:
         def __rfloordiv__(self, other: Any) -> "VectorMath": ...
         def __neg__(self) -> "VectorMath": ...
         def __abs__(self) -> "VectorMath": ...
-        def __lt__(self, other: Any) -> "Compare": ...
-        def __gt__(self, other: Any) -> "Compare": ...
-        def __le__(self, other: Any) -> "Compare": ...
-        def __ge__(self, other: Any) -> "Compare": ...
-        def __eq__(self, other: Any) -> "Compare": ...  # type: ignore[override]
-        def __ne__(self, other: Any) -> "Compare": ...  # type: ignore[override]
+        def __lt__(self, other: Any) -> "Compare[NodeSocketVector]": ...
+        def __gt__(self, other: Any) -> "Compare[NodeSocketVector]": ...
+        def __le__(self, other: Any) -> "Compare[NodeSocketVector]": ...
+        def __ge__(self, other: Any) -> "Compare[NodeSocketVector]": ...
 
 
 _SEPARATE_COLOR_IDNAMES = (
@@ -356,7 +355,9 @@ class _ColorMixin:
         return SeparateColor
 
     def _separated_channel(self, channel: str) -> Socket:
+        assert self.socket.links is not None
         for link in self.socket.links:
+            assert link.to_node is not None
             if link.to_node.bl_idname in _SEPARATE_COLOR_IDNAMES:
                 return Socket(link.to_node.outputs[channel])
 
@@ -448,9 +449,15 @@ class _ColorMixin:
         if operation == "multiply":
             if isinstance(other, (int, float)):
                 return VectorMath.scale(self.socket, other)
-            elif isinstance(other, NodeSocket) and other.type in ("VALUE", "FLOAT", "INT"):
+            elif isinstance(other, NodeSocket) and other.type in (
+                "VALUE",
+                "FLOAT",
+                "INT",
+            ):
                 return VectorMath.scale(self.socket, other)
-            elif isinstance(other, (_SocketLike, _NodeLike)) and getattr(other, "type", None) in ("VALUE", "FLOAT", "INT"):
+            elif isinstance(other, (_SocketLike, _NodeLike)) and getattr(
+                other, "type", None
+            ) in ("VALUE", "FLOAT", "INT"):
                 return VectorMath.scale(self.socket, other._default_output_socket)
             else:
                 return VectorMath.multiply(*values)
@@ -465,7 +472,9 @@ class _ColorMixin:
                         else vector_method(scalar_vector, self.socket)
                     )
                 return vector_method(*values)
-            return Socket._dispatch_math(self, other, operation, reverse)  # type: ignore[arg-type]
+            return Socket._dispatch_math(
+                cast("Socket", self), other, operation, reverse
+            )
 
 
 class _IntegerMixin:
@@ -504,7 +513,7 @@ class _IntegerMixin:
 
             values = (self.socket, other) if not reverse else (other, self.socket)
             return getattr(IntegerMath, operation)(*values)
-        return Socket._dispatch_math(self, other, operation, reverse)  # type: ignore[arg-type]
+        return Socket._dispatch_math(cast("Socket", self), other, operation, reverse)
 
     def _dispatch_unary(self, operation: str) -> "BaseNode":
         if self._is_geometry_tree:
@@ -514,7 +523,7 @@ class _IntegerMixin:
                 return IntegerMath.negate(self.socket)
             elif operation == "absolute":
                 return IntegerMath.absolute(self.socket)
-        return Socket._dispatch_unary(self, operation)  # type: ignore[arg-type]
+        return Socket._dispatch_unary(cast("Socket", self), operation)
 
     def _dispatch_floordiv(self, other: Any, reverse: bool = False) -> "BaseNode":
         if self._is_geometry_tree and self._other_is_integer(other):
@@ -522,14 +531,14 @@ class _IntegerMixin:
 
             values = (self.socket, other) if not reverse else (other, self.socket)
             return IntegerMath.divide_floor(*values)
-        return Socket._dispatch_floordiv(self, other, reverse)  # type: ignore[arg-type]
+        return Socket._dispatch_floordiv(cast("Socket", self), other, reverse)
 
     def _dispatch_compare(self, other: Any, operation: str) -> "BaseNode":
         if isinstance(self._tree.tree, GeometryNodeTree):
             from ..nodes.geometry.manual import Compare
 
             return getattr(Compare.integer, operation)(self.socket, other)
-        return Socket._dispatch_compare(self, other, operation)  # type: ignore[arg-type]
+        return Socket._dispatch_compare(cast("Socket", self), other, operation)
 
     if TYPE_CHECKING:
 
@@ -545,12 +554,10 @@ class _IntegerMixin:
         def __rfloordiv__(self, other: Any) -> "IntegerMath": ...
         def __neg__(self) -> "IntegerMath": ...
         def __abs__(self) -> "IntegerMath": ...
-        def __lt__(self, other: Any) -> "Compare": ...
-        def __gt__(self, other: Any) -> "Compare": ...
-        def __le__(self, other: Any) -> "Compare": ...
-        def __ge__(self, other: Any) -> "Compare": ...
-        def __eq__(self, other: Any) -> "Compare": ...  # type: ignore[override]
-        def __ne__(self, other: Any) -> "Compare": ...  # type: ignore[override]
+        def __lt__(self, other: Any) -> "Compare[NodeSocketInt]": ...
+        def __gt__(self, other: Any) -> "Compare[NodeSocketInt]": ...
+        def __le__(self, other: Any) -> "Compare[NodeSocketInt]": ...
+        def __ge__(self, other: Any) -> "Compare[NodeSocketInt]": ...
 
 
 # ---------------------------------------------------------------------------

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -438,6 +438,35 @@ class _ColorMixin:
     def __len__(self) -> int:
         return 4
 
+    def _dispatch_math(
+        self, other: Any, operation: str, reverse: bool = False
+    ) -> "BaseNode":
+        from ..nodes.geometry import VectorMath
+
+        values = (self.socket, other) if not reverse else (other, self.socket)
+
+        if operation == "multiply":
+            if isinstance(other, (int, float)):
+                return VectorMath.scale(self.socket, other)
+            elif isinstance(other, NodeSocket) and other.type in ("VALUE", "FLOAT", "INT"):
+                return VectorMath.scale(self.socket, other)
+            elif isinstance(other, (_SocketLike, _NodeLike)) and getattr(other, "type", None) in ("VALUE", "FLOAT", "INT"):
+                return VectorMath.scale(self.socket, other._default_output_socket)
+            else:
+                return VectorMath.multiply(*values)
+        else:
+            vector_method = getattr(VectorMath, operation, None)
+            if vector_method is not None:
+                if isinstance(other, (int, float)):
+                    scalar_vector = (other, other, other)
+                    return (
+                        vector_method(self.socket, scalar_vector)
+                        if not reverse
+                        else vector_method(scalar_vector, self.socket)
+                    )
+                return vector_method(*values)
+            return Socket._dispatch_math(self, other, operation, reverse)  # type: ignore[arg-type]
+
 
 class _IntegerMixin:
     """Integer-specific dispatch — uses IntegerMath in geometry trees."""

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -101,7 +101,7 @@ class Socket(_SocketLike, OperatorMixin, LinkingMixin):
 
     def _dispatch_math(
         self, other: Any, operation: str, reverse: bool = False
-    ) -> "BaseNode":
+    ) -> "Math":
         """Scalar math dispatch (float). Uses the Math node."""
         from ..nodes.geometry.converter import Math
 

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -466,18 +466,15 @@ class _ColorMixin:
                 return VectorMath.multiply(*values)
         else:
             vector_method = getattr(VectorMath, operation, None)
-            if vector_method is not None:
-                if isinstance(other, (int, float)):
-                    scalar_vector = (other, other, other)
-                    return (
-                        vector_method(self.socket, scalar_vector)
-                        if not reverse
-                        else vector_method(scalar_vector, self.socket)
-                    )
-                return vector_method(*values)
-            return Socket._dispatch_math(
-                cast("Socket", self), other, operation, reverse
-            )
+            assert vector_method is not None
+            if isinstance(other, (int, float)):
+                scalar_vector = (other, other, other)
+                return (
+                    vector_method(self.socket, scalar_vector)
+                    if not reverse
+                    else vector_method(scalar_vector, self.socket)
+                )
+            return vector_method(*values)
 
 
 class _IntegerMixin:

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -109,7 +109,7 @@ class Socket(_SocketLike, OperatorMixin, LinkingMixin):
         math_operation = "floored_modulo" if operation == "modulo" else operation
         return getattr(Math, math_operation)(*values)
 
-    def _dispatch_unary(self, operation: str) -> "BaseNode":
+    def _dispatch_unary(self, operation: str) -> "Math":
         """Scalar unary dispatch (float). Uses the Math node."""
         from ..nodes.geometry.converter import Math
 
@@ -119,7 +119,7 @@ class Socket(_SocketLike, OperatorMixin, LinkingMixin):
             return Math.absolute(self.socket)
         raise ValueError(f"Unknown unary operation: {operation}")
 
-    def _dispatch_floordiv(self, other: Any, reverse: bool = False) -> "BaseNode":
+    def _dispatch_floordiv(self, other: Any, reverse: bool = False) -> "Math":
         """Scalar floor division: divide then floor."""
         from ..nodes.geometry.converter import Math
 
@@ -127,7 +127,7 @@ class Socket(_SocketLike, OperatorMixin, LinkingMixin):
         divided = Math.divide(*values)
         return Math.floor(divided)
 
-    def _dispatch_compare(self, other: Any, operation: str) -> "BaseNode":
+    def _dispatch_compare(self, other: Any, operation: str) -> "Compare | Math":
         """Scalar comparison dispatch."""
         if isinstance(self._tree.tree, GeometryNodeTree):
             from ..nodes.geometry.manual import Compare

--- a/src/nodebpy/types.py
+++ b/src/nodebpy/types.py
@@ -157,6 +157,7 @@ _SocketShapeStructureType = Literal["AUTO", "DYNAMIC", "FIELD", "GRID", "SINGLE"
 
 
 SOCKET_TYPES = Literal[
+    "VALUE",
     "FLOAT",
     "INT",
     "BOOLEAN",
@@ -174,6 +175,8 @@ SOCKET_TYPES = Literal[
     "BUNDLE",
     "CLOSURE",
     "SHADER",
+    "FONT",
+    "CUSTOM",
 ]
 
 SOCKET_COMPATIBILITY: dict[str, tuple[str, ...]] = {

--- a/tests/test_compositor.py
+++ b/tests/test_compositor.py
@@ -5,81 +5,77 @@ from nodebpy import sockets as s
 
 def test_initial_compositor():
     with c.tree("comp", fake_user=True) as t:
-        with t.inputs:
-            image = s.SocketColor("Image")
-            depth = s.SocketFloat("Depth")
-            normal = s.SocketVector("Normal")
-            ao = s.SocketColor("AO")
+        image = t.inputs.color("Image")
+        depth = t.inputs.float("Depth")
+        normal = t.inputs.vector("Normal")
+        ao = t.inputs.float("AO")
+        background_menu = t.inputs.menu("Background", "Output")
+        background_color = t.inputs.color("Background Color")
+        outline_menu = t.inputs.menu(
+            "Outline", "Outline", expanded=True, optional_label=True
+        )
+        outline_depth = t.inputs.float("Socket Depth", 5.0)
+        outline_size = t.inputs.integer("Outline Size", 2)
+        outline_color = t.inputs.color("Outline Color")
 
-            background_menu = s.SocketMenu("Background", "Output")
-            background_color = s.SocketColor("Background Color")
-            outline_menu = s.SocketMenu(
-                "Outline", "Outline", expanded=True, optional_label=True
+        output_color = t.outputs.color("Image")
+
+        with c.Frame("Ambient Occlusion"):
+            ao_factor = (1 - ao) ** 0.94 >> c.Kuwahara(..., size=4.0)
+            active_image = c.Mix.color(ao_factor, image)
+        with c.Frame("Outline"):
+            depth_line = c.Filter.sobel(depth) > (outline_depth / 100)
+            normal_line = c.Filter.sobel(normal) > 1.5
+            outline_comp = (
+                (depth_line + normal_line)
+                >> c.AntiAliasing()
+                >> c.Dilateerode.distance(size=outline_size - 1.0)
+                >> c.AntiAliasing()
             )
 
-            outline_depth = s.SocketFloat("Socket Depth", 5.0)
-            outline_size = s.SocketInteger("Outline Size", 2)
-            outline_color = s.SocketColor("Outline Color")
-
-        with t.outputs:
-            output_color = s.SocketColor("Image")
-
-        ao_factor = c.InvertColor(ao) ** 0.94 >> c.Kuwahara(..., size=4.0)
-        active_image = c.Mix.color(ao_factor, image)
-        depth_line = c.Filter.sobel(depth) > (outline_depth / 100)
-        normal_line = c.Filter.sobel(normal) > 1.5
-        outline_comp = (
-            (depth_line + normal_line)
-            >> c.AntiAliasing()
-            >> c.Dilateerode(type="Distance", size=outline_size - 1.0)
-            >> c.AntiAliasing()
-        )
-
-        outline_switch = c.MenuSwitch.color(
-            **{
-                "None": active_image,
-                "Outline": c.AlphaOver(outline_comp, outline_color),
-            },
-            menu=outline_menu,
-        )
-
-        _ = (
-            c.MenuSwitch.color(
-                outline_switch,
-                c.AlphaOver(background_color, outline_switch),
-                menu=background_menu,
+        with c.Frame("Final Composit"):
+            outline_switch = c.MenuSwitch.color(
+                **{
+                    "None": active_image,
+                    "Outline": c.AlphaOver(outline_comp, outline_color),
+                },
+                menu=outline_menu,
             )
-            >> output_color
-        )
+
+            _ = (
+                c.MenuSwitch.color(
+                    outline_switch,
+                    c.AlphaOver(background_color, outline_switch),
+                    menu=background_menu,
+                )
+                >> output_color
+            )
 
 
 def test_compositor_menu_switch():
-    with TreeBuilder.compositor() as tree:
+    with c.tree() as tree:
         menu = c.MenuSwitch.string(*[str(x) for x in range(10)])
-        with tree.outputs:
-            _ = menu >> s.SocketString()
+        menu >> tree.outputs.string()
 
     assert len(menu.node.enum_items) == 10
     assert menu.node.outputs[0].links
 
-    with TreeBuilder.compositor() as tree:
+    with c.tree() as tree:
         menu = c.MenuSwitch.float(
             **{f"Input_{i}": float(value) for i, value in enumerate(range(10))}
         )
-        with tree.outputs:
-            _ = menu >> s.SocketFloat()
+        menu >> tree.outputs.float()
 
     assert len(menu.node.enum_items) == 10
     for i, input in enumerate([x for x in menu.inputs._values() if x.type == "VALUE"]):
         assert f"Input_{i}" == input.name
         assert float(i) == input.socket.default_value
 
-    with TreeBuilder.shader() as tree:
+    with c.tree() as tree:
         menu = c.MenuSwitch.float(
             **{f"Input_{i}": c.Value(value) for i, value in enumerate(range(10))}
         )
-        with tree.outputs:
-            _ = menu >> s.SocketFloat()
+        menu >> tree.outputs.float()
 
     assert len(menu.node.enum_items) == 10
     for i, input in enumerate([x for x in menu.inputs._values() if x.type == "VALUE"]):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -949,3 +949,13 @@ class TestMatrixMultiplcation:
             .from_node.bl_idname
             == g.MultiplyMatrices._bl_idname
         )
+
+
+class TestColorSocketOperatorMath:
+    def test_color_socket_operator_math(self):
+        "Multiplies a color by a scalar and verifies the result is a VectorMath node."
+        with g.tree("ColorSocketOperatorMath") as tree:
+            color = tree.inputs.color("Color")
+            result = color * 0.01
+
+        assert result.node.bl_idname == g.VectorMath._bl_idname

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -965,7 +965,7 @@ class TestColorSocketOperatorMath:
             result5 = color ** g.Value(3.0)
             result6 = color * (0.1, 0.2, 0.3)
             result7 = color**0.1
-            result8 = color.socket * g.Vector().o.vector.socket
+            result8 = color * g.Vector().o.vector.socket
 
         assert result.node.bl_idname == g.VectorMath._bl_idname
         assert result2.node.bl_idname == g.VectorMath._bl_idname
@@ -983,8 +983,8 @@ class TestColorSocketOperatorMath:
         assert result7.i.vector_001.default_value == pytest.approx((0.1, 0.1, 0.1))
         assert result8.node.bl_idname == g.VectorMath._bl_idname
         assert result8.operation == "MULTIPLY"
-        assert result8.i[0].links.from_node == color.node
-        assert result8.i[1].links.from_node.bl_idname == g.Vector._bl_idname
+        assert result8.i[0].links[0].from_node == color.node
+        assert result8.i[1].links[0].from_node.bl_idname == g.Vector._bl_idname
 
 
 class TestIntegerSocketOperators:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -966,7 +966,8 @@ class TestColorSocketOperatorMath:
             result6 = color * (0.1, 0.2, 0.3)
             result7 = color**0.1
             result8 = color * g.Value().o.value.socket
-            result9 = g.Integer().integer == g.Value().o.value
+            result9 = g.Value().o.value == g.Integer().o.integer.socket
+            result10 = g.Integer().o.integer == g.Value().o.value
 
         assert result.node.bl_idname == g.VectorMath._bl_idname
         assert result2.node.bl_idname == g.VectorMath._bl_idname
@@ -988,6 +989,8 @@ class TestColorSocketOperatorMath:
         assert result8.i.scale.links[0].from_node.bl_idname == g.Value._bl_idname
         assert result9.operation == "EQUAL"
         assert result9.data_type == "FLOAT"
+        assert result10.operation == "EQUAL"
+        assert result10.data_type == "FLOAT"
 
 
 class TestIntegerSocketOperators:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -965,7 +965,7 @@ class TestColorSocketOperatorMath:
             result5 = color ** g.Value(3.0)
             result6 = color * (0.1, 0.2, 0.3)
             result7 = color**0.1
-            result8 = color * g.Vector().o.vector.socket
+            result8 = color * g.Value().o.value.socket
 
         assert result.node.bl_idname == g.VectorMath._bl_idname
         assert result2.node.bl_idname == g.VectorMath._bl_idname
@@ -982,9 +982,9 @@ class TestColorSocketOperatorMath:
         assert result7.operation == "POWER"
         assert result7.i.vector_001.default_value == pytest.approx((0.1, 0.1, 0.1))
         assert result8.node.bl_idname == g.VectorMath._bl_idname
-        assert result8.operation == "MULTIPLY"
-        assert result8.i[0].links[0].from_node == color.node
-        assert result8.i[1].links[0].from_node.bl_idname == g.Vector._bl_idname
+        assert result8.operation == "SCALE"
+        assert result8.i.vector.links[0].from_node == color.node
+        assert result8.i.scale.links[0].from_node.bl_idname == g.Value._bl_idname
 
 
 class TestIntegerSocketOperators:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -965,6 +965,7 @@ class TestColorSocketOperatorMath:
             result5 = color ** g.Value(3.0)
             result6 = color * (0.1, 0.2, 0.3)
             result7 = color**0.1
+            result8 = color.socket * g.Vector().o.vector.socket
 
         assert result.node.bl_idname == g.VectorMath._bl_idname
         assert result2.node.bl_idname == g.VectorMath._bl_idname
@@ -980,6 +981,10 @@ class TestColorSocketOperatorMath:
         assert result7.node.bl_idname == g.VectorMath._bl_idname
         assert result7.operation == "POWER"
         assert result7.i.vector_001.default_value == pytest.approx((0.1, 0.1, 0.1))
+        assert result8.node.bl_idname == g.VectorMath._bl_idname
+        assert result8.operation == "MULTIPLY"
+        assert result8.i[0].links.from_node == color.node
+        assert result8.i[1].links.from_node.bl_idname == g.Vector._bl_idname
 
 
 class TestIntegerSocketOperators:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -958,4 +958,18 @@ class TestColorSocketOperatorMath:
             color = tree.inputs.color("Color")
             result = color * 0.01
 
+            result2 = color * g.Integer(1)
+            result3 = int(1) * color
+            result4 = color * g.Value(2.0)
+
+            result5 = color ** g.Value(3.0)
+
         assert result.node.bl_idname == g.VectorMath._bl_idname
+        assert result2.node.bl_idname == g.VectorMath._bl_idname
+        assert result2.operation == "SCALE"
+        assert result3.node.bl_idname == g.VectorMath._bl_idname
+        assert result3.operation == "SCALE"
+        assert result4.node.bl_idname == g.VectorMath._bl_idname
+        assert result4.operation == "SCALE"
+        assert result5.node.bl_idname == g.VectorMath._bl_idname
+        assert result5.operation == "POWER"

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -966,6 +966,7 @@ class TestColorSocketOperatorMath:
             result6 = color * (0.1, 0.2, 0.3)
             result7 = color**0.1
             result8 = color * g.Value().o.value.socket
+            result9 = g.Integer().integer == g.Value().o.value
 
         assert result.node.bl_idname == g.VectorMath._bl_idname
         assert result2.node.bl_idname == g.VectorMath._bl_idname
@@ -985,6 +986,8 @@ class TestColorSocketOperatorMath:
         assert result8.operation == "SCALE"
         assert result8.i.vector.links[0].from_node == color.node
         assert result8.i.scale.links[0].from_node.bl_idname == g.Value._bl_idname
+        assert result9.operation == "EQUAL"
+        assert result9.data_type == "FLOAT"
 
 
 class TestIntegerSocketOperators:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -10,6 +10,7 @@ import pytest
 
 import nodebpy
 from nodebpy import TreeBuilder
+from nodebpy import compositor as c
 from nodebpy import geometry as g
 from nodebpy import sockets as s
 
@@ -958,11 +959,12 @@ class TestColorSocketOperatorMath:
             color = tree.inputs.color("Color")
             result = color * 0.01
 
-            result2 = color * g.Integer(1)
+            result2 = color * g.Integer(1).o.integer
             result3 = int(1) * color
             result4 = color * g.Value(2.0)
-
             result5 = color ** g.Value(3.0)
+            result6 = color * (0.1, 0.2, 0.3)
+            result7 = color**0.1
 
         assert result.node.bl_idname == g.VectorMath._bl_idname
         assert result2.node.bl_idname == g.VectorMath._bl_idname
@@ -973,3 +975,22 @@ class TestColorSocketOperatorMath:
         assert result4.operation == "SCALE"
         assert result5.node.bl_idname == g.VectorMath._bl_idname
         assert result5.operation == "POWER"
+        assert result6.node.bl_idname == g.VectorMath._bl_idname
+        assert result6.operation == "MULTIPLY"
+        assert result7.node.bl_idname == g.VectorMath._bl_idname
+        assert result7.operation == "POWER"
+        assert result7.i.vector_001.default_value == pytest.approx((0.1, 0.1, 0.1))
+
+
+class TestIntegerSocketOperators:
+    def test_integer_socket_operations(self):
+        "Only Geometry Nodes has Integer Math node so for now we fallback on Math"
+        with c.tree() as tree:
+            input = tree.inputs.integer()
+            result = -input
+            assert result.node.bl_idname == c.Math._bl_idname
+            assert result.operation == "MULTIPLY"
+            assert result.i.value.links
+            assert result.i.value.links[0].from_node == input.node
+            assert not result.i.value_001.links
+            assert result.i.value_001.default_value == pytest.approx(-1.0)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -999,3 +999,8 @@ class TestIntegerSocketOperators:
             assert result.i.value.links[0].from_node == input.node
             assert not result.i.value_001.links
             assert result.i.value_001.default_value == pytest.approx(-1.0)
+
+            result2 = result.o.value == input
+            assert result2.node.bl_idname == c.Math._bl_idname
+            assert result2.operation == "COMPARE"
+            assert result2.i.value_002.default_value == pytest.approx(0.00001)

--- a/tests/test_usecases.py
+++ b/tests/test_usecases.py
@@ -72,3 +72,26 @@ def test_PCA_asset():
         pca = PrincipalComponents()
 
     assert len(pca.node.node_tree.nodes) == 35
+
+
+def test_surface_hello_world():
+    with g.tree("Hello World") as tree:
+        height = tree.inputs.float("Height", 3.0)
+        omega = tree.inputs.float("Omega", 0.5)
+
+        with g.Frame("Computing the wave"):
+            with g.Frame("Distance"):
+                pos = g.Position().o.position
+                distance = g.Math.square_root(pos.x**2 + pos.y**2)
+            z = height * g.Math.sine(distance / omega) / distance
+
+        with g.Frame("Point offset & smooth"):
+            mesh = (
+                g.Grid(20, 20, 200, 200)
+                >> g.SetPosition(offset=g.CombineXYZ(z=z))
+                >> g.SetShadeSmooth.face()
+            )
+
+        mesh >> tree.outputs.geometry("Mesh")
+
+    assert len(tree) == 22


### PR DESCRIPTION
Previously was adding Math nodes for color sockets, now properly adds VectorMath nodes. Ensure proper mapping of integer math operations in non-Geometry node trees.

Fixes #55 