### PR TITLE
ENH: Add `Float()` node which wraps `Value()`

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -4,6 +4,9 @@ title: Changelog
 
 ## Unreleased
 
+### Enhancements
+- Add a `Float()` class which just wraps the `Value()` class / node but is better for hinting towards it's type and more discoverage (`[#58](https://github.com/BradyAJohnston/nodebpy/issues/58)`)
+
 ### Bug Fixes
 - Math on a `ColorSocket` now uses the `VectorMath` instead of `Math` preserving the RGB channels as XYZ. ([`#56`](https://github.com/BradyAJohnston/nodebpy/pull/56))
 

--- a/docs/custom-node-groups.qmd
+++ b/docs/custom-node-groups.qmd
@@ -3,7 +3,8 @@ title: Custom Node Groups
 ---
 
 ```{python}
-from nodebpy import CustomGeometryGroup, geometry as g
+from nodebpy import geometry as g
+from nodebpy.builder import CustomGeometryGroup
 from nodebpy.types import (
     InputFloat,
     InputInteger,

--- a/generate.py
+++ b/generate.py
@@ -119,6 +119,7 @@ GEOMETRY_CONFIG = TreeTypeConfig(
         "Compare",
         "AttributeStatistic",
         "Frame",
+        "Float",
         "tree",
     ),
     class_name_prefix_strips=[
@@ -144,6 +145,7 @@ SHADER_CONFIG = TreeTypeConfig(
         "Attribute",
         "Frame",
         "tree",
+        "Float",
         "material",
     ),
     class_name_prefix_strips=[
@@ -165,6 +167,7 @@ COMPOSITOR_CONFIG = TreeTypeConfig(
         "MenuSwitch",
         "Frame",
         "tree",
+        "Float",
     ),
     class_name_prefix_strips=[
         "CompositorNode",

--- a/src/nodebpy/__init__.py
+++ b/src/nodebpy/__init__.py
@@ -1,9 +1,5 @@
 from . import diagram, nodes, sockets
 from .builder import (
-    CustomCompositorGroup,
-    CustomGeometryGroup,
-    CustomShaderGroup,
-    NodeGroupBuilder,
     TreeBuilder,
 )
 from .nodes import compositor, geometry, shader
@@ -16,8 +12,4 @@ __all__ = [
     "sockets",
     "diagram",
     "TreeBuilder",
-    "NodeGroupBuilder",
-    "GeometryNodeGroup",
-    "ShaderNodeGroup",
-    "CompositorNodeGroup",
 ]

--- a/src/nodebpy/builder/__init__.py
+++ b/src/nodebpy/builder/__init__.py
@@ -89,6 +89,9 @@ __all__ = [
     "DynamicInputsMixin",
     # Node groups
     "NodeGroupBuilder",
+    "CustomCompositorGroup",
+    "CustomGeometryGroup",
+    "CustomShaderGroup",
     "GeometryNodeGroup",
     "ShaderNodeGroup",
     "CompositorNodeGroup",

--- a/src/nodebpy/nodes/compositor/__init__.py
+++ b/src/nodebpy/nodes/compositor/__init__.py
@@ -4,6 +4,7 @@ from .manual import (
     MenuSwitch,
     Frame,
     tree,
+    Float,
 )
 from ..geometry.color import (
     Gamma,
@@ -196,6 +197,7 @@ __all__ = (
     "FileOutput",
     "Filter",
     "Flip",
+    "Float",
     "FloatCurve",
     "Frame",
     "GaborTexture",

--- a/src/nodebpy/nodes/compositor/manual.py
+++ b/src/nodebpy/nodes/compositor/manual.py
@@ -1,9 +1,9 @@
 from typing import Literal
 
 from ...builder import TreeBuilder
-from ..geometry.manual import Frame, _MenuSwitchBase
+from ..geometry.manual import Float, Frame, _MenuSwitchBase
 
-__all__ = ["Frame", "MenuSwitch", "tree"]
+__all__ = ["Frame", "MenuSwitch", "tree", "Float"]
 
 
 def tree(

--- a/src/nodebpy/nodes/geometry/__init__.py
+++ b/src/nodebpy/nodes/geometry/__init__.py
@@ -36,6 +36,7 @@ from .manual import (
     Compare,
     AttributeStatistic,
     Frame,
+    Float,
     tree,
 )
 from .converter import (
@@ -443,6 +444,7 @@ __all__ = (
     "FilletCurve",
     "FindInString",
     "FlipFaces",
+    "Float",
     "FloatCurve",
     "FloatToInteger",
     "ForEachGeometryElementInput",

--- a/src/nodebpy/nodes/geometry/manual.py
+++ b/src/nodebpy/nodes/geometry/manual.py
@@ -106,6 +106,7 @@ __all__ = (
     "Compare",
     "AttributeStatistic",
     "Frame",
+    "Float",
 )
 
 
@@ -356,6 +357,10 @@ class Value(NodeBuilder):
     @value.setter
     def value(self, value: float):
         self.node.outputs[0].default_value = value  # type: ignore
+
+
+class Float(Value):
+    """Input numerical values to other nodes in the tree. A 'type-hinted' wrapper of the Value node."""
 
 
 ### === ###

--- a/src/nodebpy/nodes/shader/__init__.py
+++ b/src/nodebpy/nodes/shader/__init__.py
@@ -8,6 +8,7 @@ from .manual import (
     Attribute,
     Frame,
     tree,
+    Float,
     material,
 )
 from ..geometry.color import (
@@ -177,6 +178,7 @@ __all__ = (
     "Emission",
     "EnvironmentTexture",
     "EvaluateClosure",
+    "Float",
     "FloatCurve",
     "Frame",
     "Fresnel",

--- a/src/nodebpy/nodes/shader/interface.py
+++ b/src/nodebpy/nodes/shader/interface.py
@@ -7,6 +7,7 @@ import bpy
 from ...builder import BaseNode as NodeBuilder, SocketAccessor, ClosureSocket
 
 
+
 class ClosureInput(NodeBuilder):
     """
     Closure Input node

--- a/src/nodebpy/nodes/shader/manual.py
+++ b/src/nodebpy/nodes/shader/manual.py
@@ -12,7 +12,7 @@ from ...builder import (
 )
 from ...builder.accessor import SocketAccessor
 from ..geometry import Frame, RepeatInput, RepeatOutput, RepeatZone
-from ..geometry.manual import _MenuSwitchBase
+from ..geometry.manual import Float, _MenuSwitchBase
 
 __all__ = [
     "MenuSwitch",
@@ -21,6 +21,7 @@ __all__ = [
     "RepeatZone",
     "Attribute",
     "Frame",
+    "Float",
     "tree",
     "material",
 ]

--- a/tests/test_compositor.py
+++ b/tests/test_compositor.py
@@ -1,6 +1,4 @@
-from nodebpy import TreeBuilder
 from nodebpy import compositor as c
-from nodebpy import sockets as s
 
 
 def test_initial_compositor():

--- a/tests/test_custom_groups.py
+++ b/tests/test_custom_groups.py
@@ -4,14 +4,13 @@ import bpy
 import pytest
 from bpy.types import CompositorNodeTree, GeometryNodeTree, ShaderNodeTree
 
-from nodebpy import (
+from nodebpy.builder import (
     CustomCompositorGroup,
     CustomGeometryGroup,
     CustomShaderGroup,
+    SocketLinker,
     TreeBuilder,
 )
-from nodebpy.builder import SocketLinker
-from nodebpy.builder.node import DynamicInputsMixin
 from nodebpy.nodes import compositor as c
 from nodebpy.nodes import geometry as g
 from nodebpy.nodes.geometry import IntegerMath
@@ -279,7 +278,7 @@ def test_build_group_receives_instance_not_class():
             captured.append(self)
 
     with TreeBuilder():
-        node = _SelfCheck()
+        _SelfCheck()
 
     assert len(captured) == 1
     assert isinstance(captured[0], _SelfCheck)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -4,6 +4,7 @@ import bpy
 import pytest
 
 from nodebpy import TreeBuilder
+from nodebpy import compositor as c
 from nodebpy import geometry as g
 from nodebpy import shader as s
 
@@ -1073,3 +1074,20 @@ def test_geometry_nodes():
         assert not res.keep_last_segment
         res.keep_last_segment = True
         assert res.keep_last_segment
+
+
+def test_node_float_input():
+    with g.tree():
+        node = g.Float(5.0)
+        assert node.value == pytest.approx(5.0)
+        assert node.node.bl_idname == g.Value._bl_idname
+
+    with c.tree():
+        node = c.Float(5.0)
+        assert node.value == pytest.approx(5.0)
+        assert node.node.bl_idname == g.Value._bl_idname
+
+    with s.tree():
+        node = s.Float(5.0)
+        assert node.value == pytest.approx(5.0)
+        assert node.node.bl_idname == g.Value._bl_idname


### PR DESCRIPTION
This is just a type-hinted wrapper for the `Value()` node as I found myself forgetting that it was called `Value()`. The name is ultimately a legacy Blender thing and it's more discoverable to have the type in the name.

Fixes #57 