### PR TITLE
Drop `.inputs` and `.outputs` accessors

### DIFF
--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,1 +1,1 @@
-version: 0.13.0
+version: 0.13.1

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,9 +2,10 @@
 title: Changelog
 ---
 
-## v0.13.1 -
+## v0.14.0 -
 
 ### Enhancements
+- Drop the `.inputs` and `.outputs` accessors for the nodes, in favor of just using `.i` and `.o` properties directly. This will reduce confusion as `.inputs` and `.outputs` are available on the base `bpy` nodes themselves.
 - Better type hinting and stubs for the `MenuSwitch` and `IndexSwitch` nodes.
 
 ### Bug Fixes

--- a/docs/introduction.qmd
+++ b/docs/introduction.qmd
@@ -126,7 +126,7 @@ with g.tree(arrange=None) as tree:
     # this explicitly grabs the "Value" socket (which got it's name from the g.Value() node)
     # and adds 10 then attempts to plug it into the zone output (it will choose the float
     # socket instead of the vector socket because that is the most compatible)
-    zone.input.outputs["Value"] + 10 >> zone.output
+    zone.input.o["Value"] + 10 >> zone.output
     # this should automatically pick the vector input socket because we are
     # explicity about the VectorMath and it will be the most compatible
     zone.input >> g.VectorMath.add((1.2, 1.2, 1.2)) >> zone.output

--- a/docs/node-api.qmd
+++ b/docs/node-api.qmd
@@ -61,7 +61,7 @@ You can use slicing to access individual or multiple components of input and out
 ```{python}
 with g.tree() as tree:
     sep = g.SeparateXYZ(g.Position())
-    comb = g.CombineXYZ(*sep.o[:])
+    comb = g.CombineXYZ(*sep.o)
     comb2 = g.CombineXYZ()
 
     sep.o[1] >> comb2.i[2]
@@ -76,9 +76,9 @@ with g.tree() as tree:
     diff = g.FieldAverage.point.vector(pos).o.mean - pos
     matrix = g.CombineMatrix()
 
-    for i, axis1 in enumerate(diff.o.vector[:]):
+    for i, axis1 in enumerate(diff.o.vector):
         sep = g.FieldAverage.point.vector(diff * axis1)
-        for j, axis2 in enumerate(sep.o.mean[:]):
+        for j, axis2 in enumerate(sep.o.mean):
             axis2 >> matrix.i[int(i * 4 + j)]
 
 tree

--- a/src/nodebpy/builder/accessor.py
+++ b/src/nodebpy/builder/accessor.py
@@ -190,8 +190,7 @@ class SocketAccessor:
         return len(self._items())
 
     def __iter__(self):
-        """Iterate over socket names (enables ``**node.outputs`` unpacking)."""
-        return iter(self._keys())
+        return iter(self._values())
 
     def __getattr__(self, name: str) -> "Socket":
         """Dynamic socket access by normalised attribute name.

--- a/src/nodebpy/builder/mixins.py
+++ b/src/nodebpy/builder/mixins.py
@@ -196,7 +196,7 @@ class OperatorMixin:
 class LinkingMixin:
     """Node/socket linking logic: ``>>``, ``_link``, best-socket matching.
 
-    Requires ``tree``, ``inputs``, ``outputs``, ``_default_output_socket``,
+    Requires ``tree``, ``i``, ``o``, ``_default_output_socket``,
     and ``_default_input_socket`` on the concrete class.
     """
 
@@ -227,15 +227,15 @@ class LinkingMixin:
         from ..types import SOCKET_COMPATIBILITY
 
         possible_combos = []
-        if hasattr(source, "outputs"):
-            outputs = source.outputs._available  # type: ignore[union-attr]
+        if hasattr(source, "o"):
+            outputs = source.o._available  # type: ignore[union-attr]
         elif isinstance(source, NodeSocket):
             outputs = [source]
         else:
             raise TypeError(f"Cannot get outputs from {type(source)}")
 
-        if hasattr(target, "inputs"):
-            inputs = target.inputs._available  # type: ignore[union-attr]
+        if hasattr(target, "i"):
+            inputs = target.i._available  # type: ignore[union-attr]
         else:
             inputs = [target]
 
@@ -280,7 +280,7 @@ class LinkingMixin:
             try:
                 self._link(source, self.node.inputs[input])  # type: ignore[attr-defined]
             except KeyError:
-                self._link(source, self.node.inputs[self.inputs._index(input)])  # type: ignore[attr-defined]
+                self._link(source, self.node.inputs[self.i._index(input)])  # type: ignore[attr-defined]
         else:
             self._link(source, input)
 
@@ -304,8 +304,8 @@ class LinkingMixin:
             try:
                 target = other.node.inputs[name]
             except KeyError:
-                target = other.node.inputs[other.inputs._index(name)]
-            source = self.outputs._best_match(target.type)
+                target = other.node.inputs[other.i._index(name)]
+            source = self.o._best_match(target.type)
         else:
             try:
                 source, target = self._find_best_socket_pair(self, other)

--- a/src/nodebpy/builder/node.py
+++ b/src/nodebpy/builder/node.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
         def _add_inputs(self, *args: Any, **kwargs: Any) -> dict[str, NodeSocket]: ...
 
         @property
-        def inputs(self) -> SocketAccessor: ...
+        def i(self) -> SocketAccessor: ...
 
 
 class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
@@ -84,13 +84,13 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
     @property
     def _default_input_socket(self) -> NodeSocket:
         if self._default_input_id is not None:
-            return self.node.inputs[self.inputs._index(self._default_input_id)]
+            return self.node.inputs[self.i._index(self._default_input_id)]
         return self.node.inputs[0]
 
     @property
     def _default_output_socket(self) -> NodeSocket:
         if self._default_output_id is not None:
-            return self.node.outputs[self.outputs._index(self._default_output_id)]
+            return self.node.outputs[self.o._index(self._default_output_id)]
 
         counter = 0
         socket = self.node.outputs[counter]
@@ -115,7 +115,7 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
                     if link.to_node.bl_idname == cls._bl_idname:
                         return cls._from_node(link.to_node)
             node = cls()
-            node.tree.link(socket, node.inputs._best_match(socket.type))
+            node.tree.link(socket, node.i._best_match(socket.type))
             return node
         else:
             if socket.links:
@@ -164,7 +164,7 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
                 self._link_from(value, name)
             elif isinstance(value, _NodeLike):
                 self._link_from(
-                    value.outputs._best_match(self.inputs._get(name).type), name
+                    value.o._best_match(self.i._get(name).type), name
                 )
             else:
                 if name in input_ids:
@@ -176,14 +176,6 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
                     else:
                         input = self.node.inputs[name.replace("_", " ").title()]
                     self._set_input_default_value(input, value)
-
-    @property
-    def outputs(self) -> SocketAccessor:
-        return SocketAccessor(self.node.outputs, "output")
-
-    @property
-    def inputs(self) -> SocketAccessor:
-        return SocketAccessor(self.node.inputs, "input")
 
     @property
     def o(self) -> SocketAccessor:
@@ -225,7 +217,7 @@ class DynamicInputsMixin(ABC):
         except SocketError:
             dyn = cast("_DynamicTarget", target)
             target_name, source_socket = list(dyn._add_inputs(source).items())[0]
-            return (source_socket, dyn.inputs[target_name].socket)
+            return (source_socket, dyn.i[target_name].socket)
 
     @abstractmethod
     def _add_socket(self, name: str, *args: Any, **kwargs: Any) -> NodeSocket: ...
@@ -238,7 +230,7 @@ class DynamicInputsMixin(ABC):
             items[arg._default_output_socket.name] = arg
         items.update(kwargs)
         for key, source in items.items():
-            socket_source, type = self._match_compatible_data(source.outputs._available)
+            socket_source, type = self._match_compatible_data(source.o._available)
             if type in self._type_map:
                 type = self._type_map[type]
             socket = self._add_socket(name=key, type=type)

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -76,11 +76,11 @@ class Socket(_SocketLike, OperatorMixin, LinkingMixin):
         return self.socket
 
     @property
-    def outputs(self) -> SocketAccessor:
+    def o(self) -> SocketAccessor:
         return SocketAccessor([self.socket], "output")
 
     @property
-    def inputs(self) -> SocketAccessor:
+    def i(self) -> SocketAccessor:
         return SocketAccessor([self.socket], "input")
 
     @property
@@ -719,10 +719,10 @@ class _MatrixMixin:
 
         if self.socket.is_output:
             node = SeparateMatrix._find_or_create_linked(self.socket)
-            return iter(node.o[:])
+            return iter(node.o)
         else:
             node = CombineMatrix._find_or_create_linked(self.socket)
-            return iter(node.i[:])
+            return iter(node.i)
 
     def __len__(self) -> int:
         return 16

--- a/src/nodebpy/nodes/geometry/manual.py
+++ b/src/nodebpy/nodes/geometry/manual.py
@@ -481,7 +481,7 @@ class FormatString(NodeBuilder, DynamicInputsMixin):
         item = self.node.format_items.new(socket_type=type, name=name)
         if default_value is not None:
             try:
-                self.node.inputs[item.name].default_value = default_value  # type: ignore
+                self.i[item.name].default_value = default_value  # ty: ignore[unresolved-attribute]
             except TypeError as e:
                 raise ValueError(
                     f"Invalid default value for {type}: {default_value}"
@@ -491,9 +491,7 @@ class FormatString(NodeBuilder, DynamicInputsMixin):
     @property
     def items(self) -> dict[str, SocketLinker]:
         """Input sockets:"""
-        return {
-            socket.name: self.inputs._get(socket.name) for socket in self.node.inputs
-        }
+        return {socket.name: self.i._get(socket.name) for socket in self.node.inputs}
 
 
 class JoinStrings(NodeBuilder):
@@ -961,7 +959,7 @@ class IndexSwitch(NodeBuilder, Generic[_T]):
     @property
     def data_type(self) -> SOCKET_TYPES:
         """Input socket: Data Type"""
-        return self.node.data_type  # type: ignore
+        return self.node.data_type  # ty: ignore[invalid-return-type]
 
     @data_type.setter
     def data_type(self, value: SOCKET_TYPES):
@@ -1374,7 +1372,7 @@ class SDFGridBoolean(NodeBuilder):
         for arg in args:
             if arg is None:
                 continue
-            node._link_from(*node._find_best_socket_pair(arg, node.inputs["Grid 2"]))
+            node._link_from(*node._find_best_socket_pair(arg, node.i["Grid 2"]))
         return node
 
     @classmethod
@@ -1386,7 +1384,7 @@ class SDFGridBoolean(NodeBuilder):
         for arg in args:
             if arg is None:
                 continue
-            node._link_from(*node._find_best_socket_pair(arg, node.inputs["Grid 2"]))
+            node._link_from(*node._find_best_socket_pair(arg, node.i["Grid 2"]))
         return node
 
     @classmethod
@@ -1398,11 +1396,11 @@ class SDFGridBoolean(NodeBuilder):
         """Create SDF Grid Boolean with operation 'Difference'."""
         node = cls(operation="DIFFERENCE")
         if grid_1 is not None:
-            node._link_from(*node._find_best_socket_pair(grid_1, node.inputs["Grid 1"]))
+            node._link_from(*node._find_best_socket_pair(grid_1, node.i["Grid 1"]))
         for arg in args:
             if arg is None:
                 continue
-            node._link_from(*node._find_best_socket_pair(arg, node.inputs["Grid 2"]))
+            node._link_from(*node._find_best_socket_pair(arg, node.i["Grid 2"]))
         return node
 
     class _Inputs(SocketAccessor):

--- a/src/nodebpy/nodes/geometry/manual.py
+++ b/src/nodebpy/nodes/geometry/manual.py
@@ -479,13 +479,8 @@ class FormatString(NodeBuilder, DynamicInputsMixin):
         default_value: float | int | str | None = None,
     ):
         item = self.node.format_items.new(socket_type=type, name=name)
-        if default_value is not None:
-            try:
-                self.i[item.name].default_value = default_value  # ty: ignore[unresolved-attribute]
-            except TypeError as e:
-                raise ValueError(
-                    f"Invalid default value for {type}: {default_value}"
-                ) from e
+        if default_value is not None and hasattr(self.i[item.name], "default_value"):
+            self.i[item.name].default_value = default_value  # ty: ignore[unresolved-attribute]
         return self.node.inputs[item.name]
 
     @property

--- a/src/nodebpy/nodes/geometry/zone.py
+++ b/src/nodebpy/nodes/geometry/zone.py
@@ -83,7 +83,7 @@ class BaseZoneInput(BaseZone, NodeBuilder, ABC):
     def _add_socket(self, name: str, type: _BakeDataTypes):
         """Add a socket to the zone"""
         item = self.items.new(type, name)
-        return self.inputs[item.name]
+        return self.i[item.name]
 
 
 class BaseZoneOutput(BaseZone, NodeBuilder, ABC):

--- a/src/nodebpy/types.py
+++ b/src/nodebpy/types.py
@@ -157,7 +157,7 @@ _SocketShapeStructureType = Literal["AUTO", "DYNAMIC", "FIELD", "GRID", "SINGLE"
 
 
 SOCKET_TYPES = Literal[
-    "VALUE",
+    # "VALUE",
     "FLOAT",
     "INT",
     "BOOLEAN",
@@ -176,7 +176,7 @@ SOCKET_TYPES = Literal[
     "CLOSURE",
     "SHADER",
     "FONT",
-    "CUSTOM",
+    # "CUSTOM",
 ]
 
 SOCKET_COMPATIBILITY: dict[str, tuple[str, ...]] = {

--- a/tests/test_builder_coverage.py
+++ b/tests/test_builder_coverage.py
@@ -134,7 +134,7 @@ def test_link_unwraps_socket_wrappers():
     with TreeBuilder("LinkWrapTest") as tree:
         pos = g.Position()
         set_pos = g.SetPosition()
-        tree.link(pos.outputs._get("Position"), set_pos.inputs._get("Position"))
+        tree.link(pos.o._get("Position"), set_pos.i._get("Position"))
     assert len(tree.tree.links) > 0
 
 
@@ -270,7 +270,7 @@ def test_vector_compare_non_geo_tree_fallback():
     from nodebpy import shader as s
 
     with TreeBuilder.shader():
-        vec_sock = s.CombineXYZ().outputs._get("Vector")
+        vec_sock = s.CombineXYZ().o._get("Vector")
         result = vec_sock._dispatch_compare(0.5, "less_than")
     assert result is not None
 
@@ -315,14 +315,14 @@ def test_color_separate_in_compositor_tree():
 def test_rotation_socket_properties(component):
     """_RotationMixin .w/.x/.y/.z via RotationToQuaternion."""
     with TreeBuilder("RotProp"):
-        rot_sock = g.AxisAngleToRotation(angle=1.0).outputs._get("Rotation")
+        rot_sock = g.AxisAngleToRotation(angle=1.0).o._get("Rotation")
         assert getattr(rot_sock, component) is not None
 
 
 def test_rotation_socket_cached_link():
     """_RotationMixin second access reuses existing RotationToQuaternion node."""
     with TreeBuilder("RotCached"):
-        rot_sock = g.AxisAngleToRotation(angle=1.0).outputs._get("Rotation")
+        rot_sock = g.AxisAngleToRotation(angle=1.0).o._get("Rotation")
         x1 = rot_sock.x
         x2 = rot_sock.x
     assert x1 is not None and x2 is not None
@@ -332,14 +332,14 @@ def test_rotation_socket_cached_link():
 def test_matrix_socket_properties(component):
     """_MatrixMixin .translation/.rotation/.scale via SeparateTransform."""
     with TreeBuilder("MatProp"):
-        mat_sock = g.CombineTransform().outputs._get("Transform")
+        mat_sock = g.CombineTransform().o._get("Transform")
         assert getattr(mat_sock, component) is not None
 
 
 def test_matrix_socket_cached_link():
     """_MatrixMixin second access reuses existing SeparateTransform node."""
     with TreeBuilder("MatCached"):
-        mat_sock = g.CombineTransform().outputs._get("Transform")
+        mat_sock = g.CombineTransform().o._get("Transform")
         t1 = mat_sock.translation
         t2 = mat_sock.translation
     assert t1 is not None and t2 is not None
@@ -400,9 +400,9 @@ def test_find_best_socket_pair_raw_node_socket_source():
 
 
 def test_find_best_socket_pair_raw_node_socket_target():
-    """raw NodeSocket as target (no .inputs) uses [target] directly.
+    """raw NodeSocket as target (no .i) uses [target] directly.
 
-    Returns (raw_target_socket, source_output) when target has no .inputs.
+    Returns (raw_target_socket, source_output) when target has no .i.
     """
     with TreeBuilder("PairRawTgt"):
         pos = g.Position()

--- a/tests/test_compositor.py
+++ b/tests/test_compositor.py
@@ -65,7 +65,7 @@ def test_compositor_menu_switch():
         menu >> tree.outputs.float()
 
     assert len(menu.node.enum_items) == 10
-    for i, input in enumerate([x for x in menu.inputs._values() if x.type == "VALUE"]):
+    for i, input in enumerate([x for x in menu.i._values() if x.type == "VALUE"]):
         assert f"Input_{i}" == input.name
         assert float(i) == input.socket.default_value
 
@@ -76,7 +76,7 @@ def test_compositor_menu_switch():
         menu >> tree.outputs.float()
 
     assert len(menu.node.enum_items) == 10
-    for i, input in enumerate([x for x in menu.inputs._values() if x.type == "VALUE"]):
+    for i, input in enumerate([x for x in menu.i._values() if x.type == "VALUE"]):
         assert f"Input_{i}" == input.name
         assert input.socket.links[0].from_node.bl_idname == c.Value._bl_idname
         # we have to check the output defeault value here because that is how the Value

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -492,7 +492,7 @@ def test_socket_accessor():
         with pytest.raises(AttributeError, match="_some_name"):
             pos.o._some_name
 
-    assert pos.inputs._node == pos.node
+    assert pos.i._node == pos.node
 
     with g.tree() as tree:
         cube = g.Cube()
@@ -508,7 +508,7 @@ def test_socket_accessor():
 def test_accessor_slice():
     with g.tree():
         sep = g.SeparateXYZ(g.Position())
-        comb = g.CombineXYZ(*sep.o[:])
+        comb = g.CombineXYZ(*sep.o)
         comb2 = g.CombineXYZ()
 
         sep.o[1] >> comb2.i[2]
@@ -518,8 +518,8 @@ def test_accessor_slice():
         with pytest.raises(IndexError):
             sep.o[0] >> comb2.i[3]
 
-    assert all(input.links for input in comb.i[:])
-    assert all(input.links[0].from_node == sep.node for input in comb.i[:])
+    assert all(input.links for input in comb.i)
+    assert all(input.links[0].from_node == sep.node for input in comb.i)
     assert comb2.i.z.links
     assert comb2.i.z.links[0].from_node == sep.node
     assert comb2.i.z.links[0].from_socket == sep.o.y.socket
@@ -528,28 +528,28 @@ def test_accessor_slice():
 def test_accessor_slice_matrix():
     with g.tree():
         mat = g.InstanceTransform()
-        comb = g.CombineMatrix(*mat.o.transform[:])
+        comb = g.CombineMatrix(*mat.o.transform)
 
         vec = g.Position()
-        vec_comb = g.CombineXYZ(*vec.o.position[:])
+        vec_comb = g.CombineXYZ(*vec.o.position)
 
         col = g.Color()
-        col_comb = g.CombineColor(*col.o.color[:])
+        col_comb = g.CombineColor(*col.o.color)
 
-    assert all(input.links for input in comb.i[:])
+    assert all(input.links for input in comb.i)
     assert all(
-        (input.links[0].from_node.bl_idname == g.SeparateMatrix._bl_idname)  # ty: ignore[unresolved-attribute]
-        for input in comb.i[:]
+        (input.links[0].from_node.bl_idname == g.SeparateMatrix._bl_idname)
+        for input in comb.i
     )
-    assert all(input.links for input in vec_comb.i[:])
+    assert all(input.links for input in vec_comb.i)
     assert all(
-        (input.links[0].from_node.bl_idname == g.SeparateXYZ._bl_idname)  # ty: ignore[unresolved-attribute]
-        for input in vec_comb.i[:]
+        (input.links[0].from_node.bl_idname == g.SeparateXYZ._bl_idname)
+        for input in vec_comb.i
     )
-    assert all(input.links for input in col_comb.i[:])
+    assert all(input.links for input in col_comb.i)
     assert all(
-        (input.links[0].from_node.bl_idname == g.SeparateColor._bl_idname)  # ty: ignore[unresolved-attribute]
-        for input in col_comb.i[:]
+        (input.links[0].from_node.bl_idname == g.SeparateColor._bl_idname)
+        for input in col_comb.i
     )
 
 
@@ -733,8 +733,8 @@ def test_matrix_socket_output_iteration():
     assert len(components) == 16
     sep_node = components[0].socket.node
     assert all(
-        input.links[0].from_node.bl_idname == g.SeparateMatrix._bl_idname  # ty: ignore[unresolved-attribute]
-        for input in comb.i[:]
+        input.links[0].from_node.bl_idname == g.SeparateMatrix._bl_idname
+        for input in comb.i
     )
     assert sep_node
     assert sep_node.bl_idname == g.SeparateMatrix._bl_idname
@@ -746,8 +746,8 @@ def test_accessor_rotation():
     with g.tree():
         rot = g.AlignRotationToVector()
         quat = g.RotationToQuaternion(rot.o.rotation)
-        assert quat.inputs[0].links
-        rot_to_quat = quat.inputs[0].links[0].from_node
+        assert quat.i[0].links
+        rot_to_quat = quat.i[0].links[0].from_node
         assert quat.o.w.node.inputs[0].links[0].from_node == rot_to_quat  # ty: ignore[not-subscriptable]
         assert quat.o.x.node.inputs[0].links[0].from_node == rot_to_quat  # ty: ignore[not-subscriptable]
         assert quat.o.y.node.inputs[0].links[0].from_node == rot_to_quat  # ty: ignore[not-subscriptable]

--- a/tests/test_node_builder.py
+++ b/tests/test_node_builder.py
@@ -479,18 +479,18 @@ def test_auto_selection():
         # this explicitly grabs the "Value" socket (which got it's name from the n.Value() node)
         # and adds 10 then attempts to plug it into the zone output (it will choose the float
         # socket instead of the vector socket because that is the most compatible)
-        zone.input.outputs["Value"] + 10 >> zone.output
+        zone.input.o["Value"] + 10 >> zone.output
         # this should automatically pick the vector input socket because we are
         # explicity about the VectorMath and it will be the most compatible
         zone.input >> g.VectorMath.add(..., (1.2, 1.2, 1.2)) >> zone.output
 
     assert (
         tree.nodes["Math"].inputs[0].links[0].from_socket
-        == zone.input.outputs["Value"].socket
+        == zone.input.o["Value"].socket
     )
     assert (
         tree.nodes["Vector Math"].inputs[0].links[0].from_socket
-        == zone.input.outputs["Vector"].socket
+        == zone.input.o["Vector"].socket
     )
 
 
@@ -521,10 +521,10 @@ def test_placeholder():
         v = g.Color()
         mix = v >> g.Mix.color(0.3, (0.5, 0.5, 0.5, 1.0), ...)
 
-    assert not mix.inputs["Factor_Float"].socket.links
-    assert tuple(mix.inputs["A_Color"].socket.default_value) == (0.5, 0.5, 0.5, 1.0)
-    assert mix.inputs["B_Color"].socket.links
-    assert mix.inputs["B_Color"].socket.links[0].from_node == v.node
+    assert not mix.i["Factor_Float"].socket.links
+    assert tuple(mix.i["A_Color"].socket.default_value) == (0.5, 0.5, 0.5, 1.0)
+    assert mix.i["B_Color"].socket.links
+    assert mix.i["B_Color"].socket.links[0].from_node == v.node
 
 
 def test_nested_trees():
@@ -639,7 +639,7 @@ def test_add_all_nodes(module, tree_type, class_names):
                 result = output >> g.JoinGeometry()
                 assert result.node is not None
                 assert result.node.bl_idname == g.JoinGeometry._bl_idname
-                assert result.inputs[0].links[0].from_node == output.node
+                assert result.i[0].links[0].from_node == output.node
             elif NodeSocketColor.bl_rna.identifier in output.socket.bl_idname:
                 result = output >> module.SeparateColor()
                 assert result.node is not None
@@ -716,21 +716,21 @@ def test_add_all_nodes(module, tree_type, class_names):
 
 def test_iter_outputs():
     with TreeBuilder("IndexSwitch"):
-        switch = g.IndexSwitch(*g.SeparateXYZ(g.Position()).outputs._values())
+        switch = g.IndexSwitch(*g.SeparateXYZ(g.Position()).o._values())
 
     assert len(switch.node.outputs) == 1
     # 1 input for the index, another for the dynamic socket
     assert len(switch.node.inputs) == 5
 
     with TreeBuilder("MultipleOutputs") as tree:
-        for name, output in g.SeparateXYZ(g.Position()).outputs._items():
+        for name, output in g.SeparateXYZ(g.Position()).o._items():
             with tree.outputs:
                 _ = output >> socket.SocketFloat(name)
 
     with TreeBuilder("MenuSwitch") as tree:
-        switch = g.MenuSwitch.float(**dict(g.SeparateXYZ().outputs._items()))
+        switch = g.MenuSwitch.float(**dict(g.SeparateXYZ().o._items()))
 
-    assert len(switch.inputs) == 5
+    assert len(switch.i) == 5
 
 
 def test_vector_socket_linker():
@@ -810,11 +810,11 @@ class TestSocketAccessor:
 
         with TreeBuilder("IterTest"):
             pos = g.Position()
-            _assert_equal(dict(pos.outputs._items()), {"Position": pos.o.position})
+            _assert_equal(dict(pos.o._items()), {"Position": pos.o.position})
 
             setpos = g.SetPosition()
             _assert_equal(
-                dict(setpos.inputs._items()),
+                dict(setpos.i._items()),
                 {
                     "Geometry": setpos.i.geometry,
                     "Selection": setpos.i.selection,
@@ -825,10 +825,10 @@ class TestSocketAccessor:
 
             assert all(
                 [
-                    a == b
+                    a == b.name
                     for a, b in zip(
                         ["Geometry", "Selection", "Position", "Offset"],
-                        list(setpos.inputs),
+                        list(setpos.i),
                     )
                 ]
             )
@@ -838,7 +838,7 @@ class TestSocketAccessor:
         with TreeBuilder("AccessorGuardTest"):
             pos = g.Position()
             # grab a SocketAccessor while inside the context so we have a valid node
-            accessor = pos.outputs
+            accessor = pos.o
 
         # Now we're outside the context — _tree_contexts is empty.
         # This should return False rather than raise IndexError.
@@ -848,13 +848,13 @@ class TestSocketAccessor:
         """Inside a normal tree context, ignore_visibility defaults to False."""
         with TreeBuilder("NormalContext"):
             pos = g.Position()
-            assert pos.outputs._ignore_visibility is False
+            assert pos.o._ignore_visibility is False
 
     def test_ignore_visibility_inside_context_when_set_true(self):
         """Inside an ignore_visibility=True context, the flag propagates."""
         with TreeBuilder("IgnoreVisContext", ignore_visibility=True):
             pos = g.Position()
-            assert pos.outputs._ignore_visibility is True
+            assert pos.o._ignore_visibility is True
 
     def test_values_unaffected_by_ignore_visibility(self):
         """values() / items() / keys() should not change when ignore_visibility=True.
@@ -864,13 +864,13 @@ class TestSocketAccessor:
         """
         with TreeBuilder("NormalVis", arrange=None) as _:
             node_normal = g.SeparateXYZ(g.Position())
-            normal_values = node_normal.outputs._values()
-            normal_keys = node_normal.outputs._keys()
+            normal_values = node_normal.o._values()
+            normal_keys = node_normal.o._keys()
 
         with TreeBuilder("IgnoreVis", arrange=None, ignore_visibility=True) as _:
             node_ignore = g.SeparateXYZ(g.Position())
-            ignore_values = node_ignore.outputs._values()
-            ignore_keys = node_ignore.outputs._keys()
+            ignore_values = node_ignore.o._values()
+            ignore_keys = node_ignore.o._keys()
 
         # SeparateXYZ has three visible outputs (X, Y, Z) regardless of the flag.
         assert len(normal_values) == len(ignore_values)
@@ -883,11 +883,11 @@ class TestSocketAccessor:
         # accessor should expose more (or equal) sockets than without it.
         with TreeBuilder("NormalAvail", arrange=None):
             mix = g.Mix()
-            normal_available = len(mix.inputs._available)
+            normal_available = len(mix.i._available)
 
         with TreeBuilder("IgnoreAvail", arrange=None, ignore_visibility=True):
             mix = g.Mix()
-            ignore_available = len(mix.inputs._available)
+            ignore_available = len(mix.i._available)
 
         assert ignore_available >= normal_available
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -7,7 +7,13 @@ from nodebpy import TreeBuilder
 from nodebpy import compositor as c
 from nodebpy import geometry as g
 from nodebpy import shader as s
-from nodebpy.builder import FloatSocket, MatrixSocket, VectorSocket
+from nodebpy.builder import (
+    FloatSocket,
+    IntegerSocket,
+    MatrixSocket,
+    SocketString,
+    VectorSocket,
+)
 
 
 def test_capture_attribute():
@@ -85,9 +91,9 @@ class TestMathOperators:
 
             eval(f"input() {operator} 1.0 {operator} pos >> set_pos")
 
-        assert len(set_pos.i.offset.socket.links) == 0
-        assert len(set_pos.i.geometry.socket.links) == 0
-        assert len(set_pos.i.position.socket.links) == 1
+        assert len(set_pos.i.offset.links) == 0
+        assert len(set_pos.i.geometry.links) == 0
+        assert len(set_pos.i.position.links) == 1
 
 
 def test_format_string():
@@ -103,19 +109,20 @@ def test_format_string():
         )
 
         assert len(format.node.format_items) == 3
-        assert format.node.inputs[0].default_value == str_to_format  # type: ignore
-        assert format.node.inputs[1].name == "String"
-        assert format.node.inputs[1].type == "STRING"
-        assert format.node.inputs[1].default_value == ""
-        assert format.node.inputs[2].name == "x"
-        assert format.node.inputs[2].type == "INT"
-        assert format.node.inputs[2].default_value == 0  # type: ignore
-        assert format.node.inputs[3].name == "y"
-        assert format.node.inputs[3].type == "VALUE"
-        assert format.node.inputs[3].default_value == 0.0
-        assert format.items["String"].socket == format.node.inputs[1]
-        assert format.items["x"].socket == format.node.inputs[2]
-        assert format.items["y"].socket == format.node.inputs[3]
+        assert format.i[0].default_value == str_to_format  # type: ignore
+        i_string: SocketString = format.i[1]  # ty: ignore[invalid-assignment]
+        assert i_string.name == "String"
+        assert i_string.type == "STRING"
+        assert i_string.default_value == ""
+        assert format.i[2].name == "x"
+        assert isinstance(format.i[2], IntegerSocket)
+        assert format.i[2].default_value == 0
+        assert format.i[3].name == "y"
+        assert isinstance(format.i[3], FloatSocket)
+        assert format.i[3].default_value == 0.0
+        assert format.items["String"].socket == format.i[1].socket
+        assert format.items["x"].socket == format.i[2].socket
+        assert format.items["y"].socket == format.i[3].socket
 
 
 def test_field_to_grid():

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -125,15 +125,15 @@ def test_field_to_grid():
         math = g.Math.add()
 
         ftg = g.FieldToGrid(*inputs, test=g.Value())
-        _ = ftg.outputs["test"] >> math
+        _ = ftg.o["test"] >> math
 
         ftg2 = g.FieldToGrid(test_value=0.3)
-        assert ftg2.inputs["test_value"].socket.default_value == pytest.approx(0.3)
+        assert ftg2.i["test_value"].socket.default_value == pytest.approx(0.3)
 
     assert len(tree) == 9
     assert len(ftg.node.grid_items) == 6
     assert ftg.node.grid_items[5].name == "test"
-    assert ftg.outputs["test"].socket.links[0].to_socket.node == math.node
+    assert ftg.o["test"].socket.links[0].to_socket.node == math.node
     assert all(
         [i._default_output_socket.links[0].to_socket.node == ftg.node for i in inputs]
     )
@@ -150,7 +150,7 @@ def test_field_to_grid():
     assert len(ftg.node.grid_items) == 1
     assert ftg.i.topology.socket.links[0].from_node == grid.node
     assert ftg.i.topology.socket.links[0].from_socket == grid.o.grid.socket
-    assert ftg.inputs["Color"].socket.links[0].from_node.name == "Noise Texture.001"
+    assert ftg.i["Color"].socket.links[0].from_node.name == "Noise Texture.001"
 
 
 def test_field_variance():
@@ -286,7 +286,7 @@ def test_simulation(snapshot_tree):
             )
             >> output
         )
-        _ = output >> g.SetPosition(position=output.outputs["Position"])
+        _ = output >> g.SetPosition(position=output.o["Position"])
     assert len(output.node.inputs["Skip"].links) == 0
     assert len(tree) == 13
     assert snapshot_tree == tree
@@ -303,7 +303,7 @@ def test_repeat(snapshot_tree):
                 >> g.SetPosition(offset=i * g.Vector((0, 0, 0.1)) * pos_math)
                 >> output
             )
-            _ = output >> g.SetPosition(position=output.outputs["Position"])
+            _ = output >> g.SetPosition(position=output.o["Position"])
     assert len(tree) == 13
     assert len(input.items) == 2
     assert snapshot_tree == tree
@@ -368,10 +368,10 @@ def test_menu_switch():
                 name,
                 x.socket.default_value if hasattr(x.socket, "default_value") else None,
             )
-            for name, x in switch.inputs._items()
+            for name, x in switch.i._items()
         ]
     )
-    assert switch.inputs["Input_5"].socket.default_value == 5
+    assert switch.i["Input_5"].socket.default_value == 5
 
 
 def test_menu_switch_menu_connection():
@@ -379,10 +379,10 @@ def test_menu_switch_menu_connection():
         switch = g.MenuSwitch.geometry(
             cube=g.Cube(), sphere=g.UVSphere(), cone=g.Cone(), menu=g.Switch.menu()
         )
-    assert switch.inputs["Menu"].links
-    assert switch.inputs["Menu"].links[0].from_node.bl_idname == g.Switch._bl_idname
-    assert switch.inputs["Menu"].links[0].from_node.input_type == "MENU"
-    assert switch.inputs["Menu"].socket.default_value == "cube"
+    assert switch.i["Menu"].links
+    assert switch.i["Menu"].links[0].from_node.bl_idname == g.Switch._bl_idname
+    assert switch.i["Menu"].links[0].from_node.input_type == "MENU"
+    assert switch.i["Menu"].socket.default_value == "cube"
 
 
 def test_multi_menu():
@@ -412,7 +412,7 @@ def test_switch_repeatzone(snapshot_tree):
         join >> zone.output >> output
 
     assert len(zone.output.items) == 1
-    assert zone.output.inputs["Geometry"].socket.links[0].from_node == join.node
+    assert zone.output.i["Geometry"].socket.links[0].from_node == join.node
     assert snapshot_tree == tree
 
 
@@ -510,7 +510,7 @@ def test_foreachgeometryelement_zone():
         zone.output.capture_generated(pos)
         zone.output.capture_generated(transformed)
         _ = transformed >> zone.output
-        _ = g.JoinGeometry(zone.output.outputs._get("Generation_0"), cube) >> out
+        _ = g.JoinGeometry(zone.output.o._get("Generation_0"), cube) >> out
 
     input, output = zone
     with pytest.raises(IndexError):
@@ -1189,7 +1189,7 @@ def test_closure_nodes():
 
         input, output = g.ClosureZone()
         vec = g.CombineXYZ()
-        _ = [input.link(x) for x in vec.i[:]]
+        _ = [input.link(x) for x in vec.i]
         output.link(vec.o.vector)
 
         ec = g.EvaluateClosure()
@@ -1200,7 +1200,7 @@ def test_closure_nodes():
 
         output.sync_signature(ec)
         assert isinstance(output.i[0], VectorSocket)
-        assert len(input.o[:]) == 4
+        assert len(input.o) == 4
         assert isinstance(input.o[0], FloatSocket)
 
 

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -47,7 +47,7 @@ def test_shader_menu_switch():
             _ = menu >> sockets.SocketFloat()
 
     assert len(menu.node.enum_items) == 10
-    for i, input in enumerate([x for x in menu.inputs._values() if x.type == "VALUE"]):
+    for i, input in enumerate([x for x in menu.i._values() if x.type == "VALUE"]):
         assert f"Input_{i}" == input.name
         assert float(i) == input.socket.default_value
 
@@ -59,7 +59,7 @@ def test_shader_menu_switch():
             _ = menu >> sockets.SocketFloat()
 
     assert len(menu.node.enum_items) == 10
-    for i, input in enumerate([x for x in menu.inputs._values() if x.type == "VALUE"]):
+    for i, input in enumerate([x for x in menu.i._values() if x.type == "VALUE"]):
         assert input.socket.links[0].from_node.bl_idname == s.Value._bl_idname
         # we have to check the output defeault value here because that is how the Value
         # node is defined which is truly cursed but hey it is what it is

--- a/uv.lock
+++ b/uv.lock
@@ -1169,7 +1169,7 @@ wheels = [
 
 [[package]]
 name = "nodebpy"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Fixes #63

Changes the `.i` and `.o` so we can iterate them directly rather like as a dictionary.

```py
[x.name for x in g.Normal().o] # ["Normal", "True Normal"]
```

Removes the `.inputs` and `.outputs` accessors for the node builders. Instead should always just use the `.i` and `.o`. These were more convenient anyway, and can reduce confusion with the `node.node.outputs` and `node.o` where one is the base Blender socket group and the other is our helper accessor.