### PR TITLE
Change socket finding to prefer first socket for some data type pairs

### DIFF
--- a/src/nodebpy/builder/mixins.py
+++ b/src/nodebpy/builder/mixins.py
@@ -227,7 +227,7 @@ class LinkingMixin:
         """Find the best compatible pair of sockets between two nodes/sockets."""
         from ..builder.node import BaseNode
         from ..builder.socket import Socket
-        from ..types import SOCKET_COMPATIBILITY
+        from ..types import PREFER_FIRST_SOCKET, SOCKET_COMPATIBILITY
 
         possible_combos = []
         if isinstance(source, BaseNode):
@@ -248,6 +248,21 @@ class LinkingMixin:
         if getattr(getattr(target, "node", None), "bl_idname", None) == "NodeReroute":
             if outputs and inputs:
                 return inputs[0], outputs[0]
+
+        # Try first available input first — if the output type matches it exactly,
+        # or is a "preferred" implicit conversion (e.g. float→color, vector→color),
+        # use the first socket rather than searching for a better-typed later one.
+        # This keeps float→Image working in the compositor instead of drifting to
+        # a float Factor socket that scores higher on raw compatibility.
+        # Pairs not in PREFER_FIRST_SOCKET (e.g. VALUE→BOOLEAN, VECTOR→ROTATION)
+        # fall through to the ranked search below.
+        if inputs:
+            first_input = inputs[0]
+            for output in outputs:
+                if first_input.type == output.type:
+                    return first_input, output
+                if (output.type, first_input.type) in PREFER_FIRST_SOCKET:
+                    return first_input, output
 
         for output in outputs:
             compat_sockets = SOCKET_COMPATIBILITY.get(output.type, ())

--- a/src/nodebpy/types.py
+++ b/src/nodebpy/types.py
@@ -230,6 +230,23 @@ SOCKET_COMPATIBILITY: dict[str, tuple[str, ...]] = {
     "SHADER": ("SHADER", "RGBA"),
 }
 
+# Type pairs (output, input) where the first available input socket should be
+# preferred over a later socket with a closer type match. Covers the common
+# float ↔ color ↔ vector implicit conversions in compositor / shader nodes.
+# Intentionally excludes low-semantic-overlap pairs like VALUE→BOOLEAN or
+# VECTOR→ROTATION, which should still fall through to best-match logic.
+PREFER_FIRST_SOCKET: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("VALUE", "RGBA"),
+        ("RGBA", "VALUE"),
+        ("VECTOR", "RGBA"),
+        ("RGBA", "VECTOR"),
+        ("VALUE", "SHADER"),
+        ("VECTOR", "SHADER"),
+        ("RGBA", "SHADER"),
+    }
+)
+
 
 FloatInterfaceSubtypes = typing.Literal[
     "NONE",

--- a/tests/__snapshots__/test_compositor.ambr
+++ b/tests/__snapshots__/test_compositor.ambr
@@ -1,0 +1,60 @@
+# serializer version: 1
+# name: test_initial_compositor
+  '''
+  ```{mermaid}
+  graph LR
+      N0("Group Input"):::default-node
+      N1("Math<br/><small>(SUBTRACT)</small>"):::converter-node
+      N2("Filter"):::default-node
+      N3("Filter"):::default-node
+      N4("Math<br/><small>(DIVIDE)</small>"):::converter-node
+      N5("Math<br/><small>(POWER)</small>"):::converter-node
+      N6("Math<br/><small>(GREATER_THAN)</small>"):::converter-node
+      N7("Math<br/><small>(GREATER_THAN)</small>"):::converter-node
+      N8("Kuwahara"):::default-node
+      N9("Math<br/><small>(ADD)</small>"):::converter-node
+      N10("Mix<br/><small>(0.5,0.5,0.5)</small>"):::default-node
+      N11("Anti-Aliasing"):::default-node
+      N12("Math<br/><small>(SUBTRACT)</small>"):::converter-node
+      N13("Frame"):::default-node
+      N14("Frame"):::default-node
+      N15("Frame"):::default-node
+      N16("Dilate/Erode"):::default-node
+      N17("Anti-Aliasing"):::default-node
+      N18("Alpha Over"):::default-node
+      N19("Menu Switch"):::converter-node
+      N20("Alpha Over"):::default-node
+      N21("Menu Switch"):::converter-node
+      N22("Group Output"):::default-node
+      N0 -->|"AO->Value"| N1
+      N1 -->|"Value->Value"| N5
+      N5 -->|"Value->Image"| N8
+      N8 -->|"Image->Factor"| N10
+      N0 -->|"Image->A"| N10
+      N0 -->|"Depth->Image"| N2
+      N0 -->|"Socket Depth->Value"| N4
+      N2 -->|"Image->Value"| N6
+      N4 -->|"Value->Value"| N6
+      N0 -->|"Normal->Image"| N3
+      N3 -->|"Image->Value"| N7
+      N6 -->|"Value->Value"| N9
+      N7 -->|"Value->Value"| N9
+      N9 -->|"Value->Image"| N11
+      N12 -->|"Value->Size"| N16
+      N11 -->|"Image->Mask"| N16
+      N16 -->|"Mask->Image"| N17
+      N17 -->|"Image->Background"| N18
+      N18 -->|"Image->Outline"| N19
+      N19 -->|"Output->Foreground"| N20
+      N20 -->|"Image->Image"| N21
+      N21 -->|"Output->Image"| N22
+      N0 -->|"Background->Menu"| N21
+      N0 -->|"Background Color->Background"| N20
+      N0 -->|"Outline->Menu"| N19
+      N0 -->|"Outline Size->Value"| N12
+      N0 -->|"Outline Color->Foreground"| N18
+      N10 -->|"Result->None"| N19
+      N19 -->|"Output->Output"| N21
+  ```
+  '''
+# ---

--- a/tests/test_compositor.py
+++ b/tests/test_compositor.py
@@ -1,7 +1,7 @@
 from nodebpy import compositor as c
 
 
-def test_initial_compositor():
+def test_initial_compositor(snapshot):
     with c.tree("comp", fake_user=True) as t:
         image = t.inputs.color("Image")
         depth = t.inputs.float("Depth")
@@ -19,11 +19,11 @@ def test_initial_compositor():
         output_color = t.outputs.color("Image")
 
         with c.Frame("Ambient Occlusion"):
-            ao_factor = (1 - ao) ** 0.94 >> c.Kuwahara(..., size=4.0)
+            ao_factor = (1 - ao) ** 0.94 >> c.Kuwahara(size=4.0)
             active_image = c.Mix.color(ao_factor, image)
         with c.Frame("Outline"):
-            depth_line = c.Filter.sobel(depth) > (outline_depth / 100)
-            normal_line = c.Filter.sobel(normal) > 1.5
+            depth_line = depth >> c.Filter.sobel() > (outline_depth / 100)
+            normal_line = normal >> c.Filter.sobel() > 1.5
             outline_comp = (
                 (depth_line + normal_line)
                 >> c.AntiAliasing()
@@ -48,6 +48,7 @@ def test_initial_compositor():
                 )
                 >> output_color
             )
+    assert snapshot == t._repr_markdown_()
 
 
 def test_compositor_menu_switch():


### PR DESCRIPTION
Fixes #64 

Previously we searched all of the inputs looking for an exact data type match before falling back on compatible but not a direct match. 

This changes the socket finding logic so the first socket is preferred for some data type combinations (RGBA -> float -> RGBA) for node chains in the compositor. 

If it doesn't match one of the pre-defined type combinations, falls back on regular matching logic.