### PR TITLE
Tweak typing for socket mixins

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -5,6 +5,8 @@ title: Changelog
 ## v0.16.0 - UNRELEASED
 
 ### Enhancements
+- Added `svd()` method onto `MatrixSocket` which returns a `tuple[MatrixSocket, VectorSocket, MatrixSocket]` for the `[u, s, v]` outputs of the `MatrixSVD` node.
+- Add `sign()` and `negate()` methods onto the `FloatSocket` for method chaining. Both return `FloatSocket`.
 - Remove `socket_name` property from `BaseSocket`, already accessible via `.socket.name`.
 - Added `.dot()`, `.length()` and `.normalize()` methods to `VectorSocket` which create the corresponding `DotProduct`, `VectorLength` and `Normalize` nodes.
 - Properties on sockets that aren't just accessing components of the socket are node methods. They still return sockets and not nodes.
@@ -14,8 +16,10 @@ title: Changelog
     - `MatrixSocket.transpose` -> `MatrixSocket.transpose()`
     - `MatrixSocket.determinant` -> `MatrixSocket.determinant()`
 
-
 ### Bug Fixes
+- The `ColorSocket` properly only indexes to length `3` inside of the shader as `SeparateXYZ` and `CombineXYZ` don't have alpha inputs or outputs.
+- Socket return types are more explicit for slicing and math operations for better quality type hinting.
+
 
 ## v0.15.0 - 2026-04-30
 

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -60,7 +60,6 @@ if TYPE_CHECKING:
         IntegerMath,
         Math,
         MultiplyMatrices,
-        Switch,
         TransformPoint,
     )
     from ..nodes.geometry.manual import Compare
@@ -232,19 +231,19 @@ class _VectorMixin(BaseSocket):
     _tree: TreeBuilder
 
     @property
-    def x(self) -> Socket:
+    def x(self) -> FloatSocket:
         from ..nodes.geometry import SeparateXYZ
 
         return SeparateXYZ._find_or_create_linked(self.socket).o.x
 
     @property
-    def y(self) -> Socket:
+    def y(self) -> FloatSocket:
         from ..nodes.geometry import SeparateXYZ
 
         return SeparateXYZ._find_or_create_linked(self.socket).o.y
 
     @property
-    def z(self) -> Socket:
+    def z(self) -> FloatSocket:
         from ..nodes.geometry import SeparateXYZ
 
         return SeparateXYZ._find_or_create_linked(self.socket).o.z
@@ -285,18 +284,21 @@ class _VectorMixin(BaseSocket):
         self.socket.default_value = value
 
     @overload
-    def __getitem__(self, key: slice) -> "list[Socket]": ...
+    def __getitem__(self, key: slice) -> "list[FloatSocket]": ...
     @overload
-    def __getitem__(self, key: int) -> "Socket": ...
-    def __getitem__(self, key: int | slice) -> "Socket | list[Socket]":
+    def __getitem__(self, key: int) -> "FloatSocket": ...
+    def __getitem__(self, key: int | slice) -> "FloatSocket | list[FloatSocket]":
         from ..nodes.geometry import CombineXYZ, SeparateXYZ
 
         if self.socket.is_output:
-            return SeparateXYZ._find_or_create_linked(self.socket).o[key]
-        else:
-            return CombineXYZ._find_or_create_linked(self.socket).i[key]
+            node = SeparateXYZ._find_or_create_linked(self.socket)
+            return [node.o.x, node.o.y, node.o.z][key]
 
-    def __iter__(self) -> Iterator["Socket"]:
+        else:
+            node = CombineXYZ._find_or_create_linked(self.socket)
+            return [node.i.x, node.i.y, node.i.z][key]
+
+    def __iter__(self) -> Iterator["FloatSocket"]:
         from ..nodes.geometry import CombineXYZ, SeparateXYZ
 
         if self.socket.is_output:
@@ -324,7 +326,7 @@ class _VectorMixin(BaseSocket):
 
     def _dispatch_math(
         self, other: Any, operation: str, reverse: bool = False
-    ) -> "BaseNode":
+    ) -> "VectorMath":
         from ..nodes.geometry import VectorMath
 
         values = (self.socket, other) if not reverse else (other, self.socket)
@@ -372,13 +374,15 @@ class _VectorMixin(BaseSocket):
                     f"Unsupported type for {operation} with VECTOR operand: {type(other)}"
                 )
 
-    def _dispatch_floordiv(self, other: Any, reverse: bool = False) -> "BaseNode":
+    def _dispatch_floordiv(self, other: Any, reverse: bool = False) -> "VectorMath":
         from ..nodes.geometry import VectorMath
 
         divided = self._dispatch_math(other, "divide", reverse=reverse)
         return VectorMath.floor(divided)
 
-    def _dispatch_compare(self, other: Any, operation: str) -> "BaseNode":
+    def _dispatch_compare(
+        self, other: Any, operation: str
+    ) -> "Compare[VectorSocket] | VectorMath":
         if self._is_geometry_tree:
             from ..nodes.geometry.manual import Compare
 
@@ -664,90 +668,80 @@ class _BooleanSwitchSocketFactory:
 
         self._switch = Switch
 
-    def float(
-        self, false: InputFloat = None, true: InputFloat = None
-    ) -> "Switch[FloatSocket]":
-        return self._switch.float(self._socket, false, true)
+    def float(self, false: InputFloat = None, true: InputFloat = None) -> "FloatSocket":
+        return self._switch.float(self._socket, false, true).o.output
 
     def integer(
         self, false: InputInteger = None, true: InputInteger = None
-    ) -> "Switch[IntegerSocket]":
-        return self._switch.integer(self._socket, false, true)
+    ) -> "IntegerSocket":
+        return self._switch.integer(self._socket, false, true).o.output
 
     def boolean(
         self, false: InputBoolean = None, true: InputBoolean = None
-    ) -> "Switch[BooleanSocket]":
-        return self._switch.boolean(self._socket, false, true)
+    ) -> "BooleanSocket":
+        return self._switch.boolean(self._socket, false, true).o.output
 
     def vector(
         self, false: InputVector = None, true: InputVector = None
-    ) -> "Switch[VectorSocket]":
-        return self._switch.vector(self._socket, false, true)
+    ) -> "VectorSocket":
+        return self._switch.vector(self._socket, false, true).o.output
 
-    def color(
-        self, false: InputColor = None, true: InputColor = None
-    ) -> "Switch[ColorSocket]":
-        return self._switch.color(self._socket, false, true)
+    def color(self, false: InputColor = None, true: InputColor = None) -> "ColorSocket":
+        return self._switch.color(self._socket, false, true).o.output
 
     def rotation(
         self, false: InputRotation = None, true: InputRotation = None
-    ) -> "Switch[RotationSocket]":
-        return self._switch.rotation(self._socket, false, true)
+    ) -> "RotationSocket":
+        return self._switch.rotation(self._socket, false, true).o.output
 
     def matrix(
         self, false: InputMatrix = None, true: InputMatrix = None
-    ) -> "Switch[MatrixSocket]":
-        return self._switch.matrix(self._socket, false, true)
+    ) -> "MatrixSocket":
+        return self._switch.matrix(self._socket, false, true).o.output
 
     def string(
         self, false: InputString = None, true: InputString = None
-    ) -> "Switch[StringSocket]":
-        return self._switch.string(self._socket, false, true)
+    ) -> "StringSocket":
+        return self._switch.string(self._socket, false, true).o.output
 
-    def menu(
-        self, false: InputMenu = None, true: InputMenu = None
-    ) -> "Switch[MenuSocket]":
-        return self._switch.menu(self._socket, false, true)
+    def menu(self, false: InputMenu = None, true: InputMenu = None) -> "MenuSocket":
+        return self._switch.menu(self._socket, false, true).o.output
 
     def object(
         self, false: InputObject = None, true: InputObject = None
-    ) -> "Switch[ObjectSocket]":
-        return self._switch.object(self._socket, false, true)
+    ) -> "ObjectSocket":
+        return self._switch.object(self._socket, false, true).o.output
 
-    def image(
-        self, false: InputImage = None, true: InputImage = None
-    ) -> "Switch[ImageSocket]":
-        return self._switch.image(self._socket, false, true)
+    def image(self, false: InputImage = None, true: InputImage = None) -> "ImageSocket":
+        return self._switch.image(self._socket, false, true).o.output
 
     def geometry(
         self, false: InputGeometry = None, true: InputGeometry = None
-    ) -> "Switch[GeometrySocket]":
-        return self._switch.geometry(self._socket, false, true)
+    ) -> "GeometrySocket":
+        return self._switch.geometry(self._socket, false, true).o.output
 
     def collection(
         self, false: InputCollection = None, true: InputCollection = None
-    ) -> "Switch[CollectionSocket]":
-        return self._switch.collection(self._socket, false, true)
+    ) -> "CollectionSocket":
+        return self._switch.collection(self._socket, false, true).o.output
 
     def material(
         self, false: InputMaterial = None, true: InputMaterial = None
-    ) -> "Switch[MaterialSocket]":
-        return self._switch.material(self._socket, false, true)
+    ) -> "MaterialSocket":
+        return self._switch.material(self._socket, false, true).o.output
 
     def bundle(
         self, false: InputBundle = None, true: InputBundle = None
-    ) -> "Switch[BundleSocket]":
-        return self._switch.bundle(self._socket, false, true)
+    ) -> "BundleSocket":
+        return self._switch.bundle(self._socket, false, true).o.output
 
     def closure(
         self, false: InputClosure = None, true: InputClosure = None
-    ) -> "Switch[ClosureSocket]":
-        return self._switch.closure(self._socket, false, true)
+    ) -> "ClosureSocket":
+        return self._switch.closure(self._socket, false, true).o.output
 
-    def font(
-        self, false: InputFont = None, true: InputFont = None
-    ) -> "Switch[FontSocket]":
-        return self._switch.font(self._socket, false, true)
+    def font(self, false: InputFont = None, true: InputFont = None) -> "FontSocket":
+        return self._switch.font(self._socket, false, true).o.output
 
 
 class _BooleanMixin(BaseSocket):
@@ -763,15 +757,15 @@ class _BooleanMixin(BaseSocket):
     def default_value(self, value: bool) -> None:
         self.socket.default_value = value
 
-    def __or__(self, other: Any) -> "BaseNode":
+    def __or__(self, other: Any) -> "BooleanSocket":
         from ..nodes.geometry.converter import BooleanMath
 
-        return BooleanMath.l_or(self.socket, other)
+        return BooleanMath.l_or(self.socket, other).o.boolean
 
-    def __and__(self, other: Any) -> "BaseNode":
+    def __and__(self, other: Any) -> "BooleanSocket":
         from ..nodes.geometry.converter import BooleanMath
 
-        return BooleanMath.l_and(self.socket, other)
+        return BooleanMath.l_and(self.socket, other).o.boolean
 
     @property
     def switch(self) -> "_BooleanSwitchSocketFactory":
@@ -795,34 +789,40 @@ class _RotationMixin(BaseSocket):
 
     @property
     def w(self) -> FloatSocket:
+        "Separate the rotation into a quaternion and return the `w` component"
         from ..nodes.geometry import RotationToQuaternion
 
         return RotationToQuaternion._find_or_create_linked(self.socket).o.w
 
     @property
     def x(self) -> FloatSocket:
+        "Separate the rotation into a quaternion and return the `x` component"
         from ..nodes.geometry import RotationToQuaternion
 
         return RotationToQuaternion._find_or_create_linked(self.socket).o.x
 
     @property
     def y(self) -> FloatSocket:
+        "Separate the rotation into a quaternion and return the `y` component"
         from ..nodes.geometry import RotationToQuaternion
 
         return RotationToQuaternion._find_or_create_linked(self.socket).o.y
 
     @property
     def z(self) -> FloatSocket:
+        "Separate the rotation into a quaternion and return the `z` component"
         from ..nodes.geometry import RotationToQuaternion
 
         return RotationToQuaternion._find_or_create_linked(self.socket).o.z
 
     def euler(self) -> "VectorSocket":
+        "Convert the rotation to an XYZ euler rotation and return `VectorSocket`."
         from ..nodes.geometry.converter import RotationToEuler
 
         return RotationToEuler._find_or_create_linked(self.socket).o.euler
 
     def invert(self) -> "RotationSocket":
+        "Invert the rotation of the socket."
         from ..nodes.geometry import InvertRotation
 
         return InvertRotation._find_or_create_linked(self.socket).o.rotation
@@ -840,6 +840,16 @@ class _FloatMixin(BaseSocket):
     @default_value.setter
     def default_value(self, value: float) -> None:
         self.socket.default_value = value
+
+    def sign(self) -> "FloatSocket":
+        "Return the sign of the FloatSocket, eithe `-1` or `1`."
+        from ..nodes.geometry import Math
+
+        return Math.sine(self.socket).o.value
+
+    def negate(self) -> "FloatSocket":
+        "Negate the `FloatSocket` by multiplying the value by `-1`."
+        return Math.multiply(self.socket, -1.0).o.value
 
 
 class _MatrixMixin(BaseSocket):
@@ -866,25 +876,34 @@ class _MatrixMixin(BaseSocket):
         return SeparateTransform._find_or_create_linked(self.socket).o.scale
 
     def determinant(self) -> "FloatSocket":
+        "Compute the determinant of a matrix input and return as a `FloatSocket`"
         from ..nodes.geometry import MatrixDeterminant
 
         return MatrixDeterminant._find_or_create_linked(self.socket).o.determinant
 
     def invert(self) -> "MatrixSocket":
+        "Invert the `MatrixSocet` and return a `MatrixSocket`"
         from ..nodes.geometry import InvertMatrix
 
         return InvertMatrix._find_or_create_linked(self.socket).o.matrix
 
     def transpose(self) -> "MatrixSocket":
+        "Transpose the `MatrixSocket` and return a `MatrixSocket`"
         from ..nodes.geometry import TransposeMatrix
 
         return TransposeMatrix._find_or_create_linked(self.socket).o.matrix
 
+    def svd(self) -> tuple[MatrixSocket, VectorSocket, MatrixSocket]:
+        "Compute the 'Single Value Decomposition' and return output sockets of the MatrixSVD node, `tuple[u, s, v]`"
+        from ..nodes.geometry import MatrixSVD
+
+        return tuple(MatrixSVD(self.socket).o)
+
     @overload
-    def __getitem__(self, key: slice) -> "list[Socket]": ...
+    def __getitem__(self, key: slice) -> "list[FloatSocket]": ...
     @overload
-    def __getitem__(self, key: int) -> "Socket": ...
-    def __getitem__(self, key: int | slice) -> "Socket | list[Socket]":
+    def __getitem__(self, key: int) -> "FloatSocket": ...
+    def __getitem__(self, key: int | slice) -> "FloatSocket | list[FloatSocket]":
         from ..nodes.geometry import CombineMatrix, SeparateMatrix
 
         if self.socket.is_output:
@@ -892,12 +911,14 @@ class _MatrixMixin(BaseSocket):
             if isinstance(key, slice):
                 return [node.o[i] for i in range(*key.indices(len(node.o)))]
             return node.o[key]
-        node = CombineMatrix._find_or_create_linked(self.socket)
-        if isinstance(key, slice):
-            return [node.i[i] for i in range(*key.indices(len(node.i)))]
+        else:
+            node = CombineMatrix._find_or_create_linked(self.socket)
+            if isinstance(key, slice):
+                return [node.i[i] for i in range(*key.indices(len(node.i)))]
+
         return node.i[key]
 
-    def __iter__(self) -> Iterator["Socket"]:
+    def __iter__(self) -> Iterator["FloatSocket"]:
         from ..nodes.geometry import CombineMatrix, SeparateMatrix
 
         if self.socket.is_output:

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -73,7 +73,7 @@ class BaseSocket:
         assert socket.node is not None
         self._tree = None
         self.socket = socket
-        self.interface_socket: bpy.types.NodeTreeInterfaceSocket | None = None
+        self._interface_socket: bpy.types.NodeTreeInterfaceSocket | None = None
 
     @property
     def node(self) -> Node:

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -50,11 +50,12 @@ from ..types import (
     InputString,
     InputVector,
 )
-from ._registry import _SOCKET_LINKER_REGISTRY, _get_socket_linker
+from ._registry import _SOCKET_LINKER_REGISTRY
 from ._utils import _NodeLike, _SocketLike
 from .mixins import LinkingMixin, OperatorMixin
 
 if TYPE_CHECKING:
+    from ..nodes import compositor, geometry, shader
     from ..nodes.geometry import (
         IntegerMath,
         Math,
@@ -104,6 +105,14 @@ class BaseSocket:
     @property
     def _is_geometry_tree(self) -> bool:
         return self.tree.tree.bl_idname == "GeometryNodeTree"
+
+    @property
+    def _is_shader_tree(self) -> bool:
+        return self.tree.tree.bl_idname == "ShaderNodeTree"
+
+    @property
+    def _is_compositor_tree(self) -> bool:
+        return self.tree.tree.bl_idname == "CompositorNodeTree"
 
     @property
     def tree(self) -> TreeBuilder:
@@ -409,45 +418,83 @@ class _ColorMixin(BaseSocket):
 
     socket: NodeSocketColor
 
-    def _separated_channel(self, channel: str) -> Socket:
+    def _separated_channel(
+        self,
+    ) -> "geometry.SeparateColor | shader.SeparateColor | compositor.SeparateColor":
         assert self.socket.links is not None
         tree_type = self.tree.tree.bl_idname
 
-        for link in self.socket.links:
-            assert link.to_node is not None
-            if link.to_node.bl_idname in _SEPARATE_COLOR_IDNAMES:
-                return Socket(link.to_node.outputs[channel])
-
         if tree_type == "ShaderNodeTree":
-            from ..nodes.shader.converter import SeparateColor
+            from ..nodes.shader import SeparateColor
 
-            sep = SeparateColor(self.socket)
+            sep = SeparateColor._find_or_create_linked(self.socket)
         elif tree_type == "CompositorNodeTree":
-            from ..nodes.compositor.converter import SeparateColor
+            from ..nodes.compositor import SeparateColor
 
-            sep = SeparateColor(self.socket)
+            sep = SeparateColor._find_or_create_linked(self.socket)
         else:
-            from ..nodes.geometry.converter import SeparateColor
+            from ..nodes.geometry import SeparateColor
 
-            sep = SeparateColor(self.socket)
+            sep = SeparateColor._find_or_create_linked(self.socket)
 
-        return sep.o[channel.lower()]
+        return sep
+
+    def _combine_color(
+        self,
+    ) -> "shader.CombineColor | compositor.CombineColor | geometry.CombineColor":
+        if self.tree.tree.bl_idname == "CompositorNodeTree":
+            from ..nodes.compositor import CombineColor
+
+            combine = CombineColor._find_or_create_linked(self.socket)
+        elif self.tree.tree.bl_idname == "ShaderNodeTree":
+            from ..nodes.shader import CombineColor
+
+            combine = CombineColor._find_or_create_linked(self.socket)
+        else:
+            from ..nodes.geometry import CombineColor
+
+            combine = CombineColor._find_or_create_linked(self.socket)
+        self.tree.link(combine.node.outputs[0], self.socket)
+        return combine
 
     @property
-    def r(self) -> Socket:
-        return self._separated_channel("Red")
+    def r(self) -> FloatSocket:
+        if self.socket.is_output:
+            return self._separated_channel().o.red
+        else:
+            return self._combine_color().i.red
 
     @property
-    def g(self) -> Socket:
-        return self._separated_channel("Green")
+    def g(self) -> FloatSocket:
+        if self.socket.is_output:
+            return self._separated_channel().o.green
+        else:
+            return self._combine_color().i.green
 
     @property
-    def b(self) -> Socket:
-        return self._separated_channel("Blue")
+    def b(self) -> FloatSocket:
+        if self.socket.is_output:
+            return self._separated_channel().o.blue
+        else:
+            return self._combine_color().i.blue
 
     @property
-    def a(self) -> Socket:
-        return self._separated_channel("Alpha")
+    def a(self) -> FloatSocket:
+        from ..nodes import shader
+
+        if self.socket.is_output:
+            node = self._separated_channel()
+            if isinstance(node, shader.SeparateColor):
+                raise TypeError(
+                    "Shader SeparateColor node doesn't have an alpha output"
+                )
+
+            return node.o.alpha
+        else:
+            node = self._combine_color()
+            if isinstance(node, shader.CombineColor):
+                raise TypeError("Shader CombineColor node doesn't have an alpha input")
+            return node.i.alpha
 
     @property
     def default_value(self) -> list[float]:
@@ -463,55 +510,32 @@ class _ColorMixin(BaseSocket):
         "CompositorNodeCombineColor",
     )
 
-    def _get_or_create_combine_color(self) -> "Node":
-        if self.socket.links:
-            for link in self.socket.links:
-                assert link.from_node
-                if link.from_node.bl_idname in self._COMBINE_COLOR_IDNAMES:
-                    return link.from_node
-
-        if self.tree.tree.bl_idname == "CompositorNodeTree":
-            from ..nodes.compositor import CombineColor
-
-            combine = CombineColor()
-        elif self.tree.tree.bl_idname == "ShaderNodeTree":
-            from ..nodes.shader import CombineColor
-
-            combine = CombineColor()
+    @overload
+    def __getitem__(self, key: slice) -> "list[FloatSocket]": ...
+    @overload
+    def __getitem__(self, key: int) -> "FloatSocket": ...
+    def __getitem__(self, key: int | slice) -> "FloatSocket | list[FloatSocket]":
+        if self._is_shader_tree:
+            return [self.r, self.g, self.b][key]
         else:
-            from ..nodes.geometry import CombineColor
-
-            combine = CombineColor()
-        self.tree.link(combine.node.outputs[0], self.socket)
-        return combine.node
-
-    @overload
-    def __getitem__(self, key: slice) -> "list[Socket]": ...
-    @overload
-    def __getitem__(self, key: int) -> "Socket": ...
-    def __getitem__(self, key: int | slice) -> "Socket | list[Socket]":
-        if self.socket.is_output:
             return [self.r, self.g, self.b, self.a][key]
-        node = self._get_or_create_combine_color()
-        return [_get_socket_linker(node.inputs[i]) for i in range(4)][key]
 
-    def __iter__(self) -> Iterator["Socket"]:
-        if self.socket.is_output:
-            yield self.r
-            yield self.g
-            yield self.b
+    def __iter__(self) -> Iterator["FloatSocket"]:
+        yield self.r
+        yield self.g
+        yield self.b
+        if not self._is_shader_tree:
             yield self.a
-        else:
-            node = self._get_or_create_combine_color()
-            for input in node.inputs:
-                yield _get_socket_linker(input)
 
     def __len__(self) -> int:
-        return 4
+        if self._is_shader_tree:
+            return 3
+        else:
+            return 4
 
     def _dispatch_math(
         self, other: Any, operation: str, reverse: bool = False
-    ) -> "BaseNode":
+    ) -> "VectorMath":
         from ..nodes.geometry import VectorMath
 
         values = (self.socket, other) if not reverse else (other, self.socket)
@@ -571,7 +595,7 @@ class _IntegerMixin(BaseSocket):
 
     def _dispatch_math(
         self, other: Any, operation: str, reverse: bool = False
-    ) -> "BaseNode":
+    ) -> "IntegerMath | Math":
         if self._is_geometry_tree and self._other_is_integer(other):
             from ..nodes.geometry.converter import IntegerMath
 
@@ -579,7 +603,7 @@ class _IntegerMixin(BaseSocket):
             return getattr(IntegerMath, operation)(*values)
         return Socket._dispatch_math(cast("Socket", self), other, operation, reverse)
 
-    def _dispatch_unary(self, operation: str) -> "BaseNode":
+    def _dispatch_unary(self, operation: str) -> "IntegerMath | Math":
         if self._is_geometry_tree:
             from ..nodes.geometry.converter import IntegerMath
 
@@ -589,7 +613,9 @@ class _IntegerMixin(BaseSocket):
                 return IntegerMath.absolute(self.socket)
         return Socket._dispatch_unary(cast("Socket", self), operation)
 
-    def _dispatch_floordiv(self, other: Any, reverse: bool = False) -> "BaseNode":
+    def _dispatch_floordiv(
+        self, other: Any, reverse: bool = False
+    ) -> "IntegerMath | Math":
         if self._is_geometry_tree and self._other_is_integer(other):
             from ..nodes.geometry.converter import IntegerMath
 
@@ -597,7 +623,9 @@ class _IntegerMixin(BaseSocket):
             return IntegerMath.divide_floor(*values)
         return Socket._dispatch_floordiv(cast("Socket", self), other, reverse)
 
-    def _dispatch_compare(self, other: Any, operation: str) -> "Compare | Math":
+    def _dispatch_compare(
+        self, other: Any, operation: str
+    ) -> "Compare[IntegerSocket] | Math":
         if self._is_geometry_tree:
             from ..nodes.geometry.manual import Compare
 

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -849,10 +849,12 @@ class _FloatMixin(BaseSocket):
         "Return the sign of the FloatSocket, eithe `-1` or `1`."
         from ..nodes.geometry import Math
 
-        return Math.sine(self.socket).o.value
+        return Math.sign(self.socket).o.value
 
     def negate(self) -> "FloatSocket":
         "Negate the `FloatSocket` by multiplying the value by `-1`."
+        from ..nodes.geometry import Math
+
         return Math.multiply(self.socket, -1.0).o.value
 
 

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -909,12 +909,18 @@ class _MatrixMixin(BaseSocket):
         if self.socket.is_output:
             node = SeparateMatrix._find_or_create_linked(self.socket)
             if isinstance(key, slice):
-                return [node.o[i] for i in range(*key.indices(len(node.o)))]
-            return node.o[key]
+                return [
+                    cast(FloatSocket, node.o[i])
+                    for i in range(*key.indices(len(node.o)))
+                ]
+            return cast(FloatSocket, node.o[key])
         else:
             node = CombineMatrix._find_or_create_linked(self.socket)
             if isinstance(key, slice):
-                return [node.i[i] for i in range(*key.indices(len(node.i)))]
+                return [
+                    cast(FloatSocket, node.i[i])
+                    for i in range(*key.indices(len(node.i)))
+                ]
 
         return node.i[key]
 

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -171,7 +171,9 @@ class Socket(BaseSocket, _SocketLike, OperatorMixin, LinkingMixin):
         divided = Math.divide(*values)
         return Math.floor(divided)
 
-    def _dispatch_compare(self, other: Any, operation: str) -> "Compare | Math":
+    def _dispatch_compare(
+        self, other: Any, operation: str
+    ) -> "Compare[FloatSocket] | Math":
         """Scalar comparison dispatch."""
         if isinstance(self.tree.tree, GeometryNodeTree):
             from ..nodes.geometry.manual import Compare
@@ -382,9 +384,9 @@ class _VectorMixin(BaseSocket):
 
     def _dispatch_compare(
         self, other: Any, operation: str
-    ) -> "Compare[VectorSocket] | VectorMath":
+    ) -> "Compare[VectorSocket] | Compare[FloatSocket] | VectorMath | Math":
         if self._is_geometry_tree:
-            from ..nodes.geometry.manual import Compare
+            from ..nodes.geometry import Compare
 
             return getattr(Compare.vector, operation)(self.socket, other)
         else:
@@ -634,7 +636,9 @@ class _IntegerMixin(BaseSocket):
             from ..nodes.geometry.manual import Compare
 
             return getattr(Compare.integer, operation)(self.socket, other)
-        return Socket._dispatch_compare(cast("Socket", self), other, operation)
+        return cast(
+            "Math", Socket._dispatch_compare(cast("Socket", self), other, operation)
+        )
 
     if TYPE_CHECKING:
 
@@ -922,7 +926,7 @@ class _MatrixMixin(BaseSocket):
                     for i in range(*key.indices(len(node.i)))
                 ]
 
-        return node.i[key]
+        return cast(FloatSocket, node.i[key])
 
     def __iter__(self) -> Iterator["FloatSocket"]:
         from ..nodes.geometry import CombineMatrix, SeparateMatrix

--- a/src/nodebpy/builder/tree.py
+++ b/src/nodebpy/builder/tree.py
@@ -141,7 +141,7 @@ class SocketContext:
             bpy_socket = self.builder._output_node().inputs[interface_socket.identifier]
         s = socket_cls(bpy_socket)
         s._tree = self.builder
-        s.interface_socket = interface_socket
+        s._interface_socket = interface_socket
         return s
 
     def float(

--- a/src/nodebpy/nodes/geometry/groups.py
+++ b/src/nodebpy/nodes/geometry/groups.py
@@ -19,8 +19,6 @@ from . import (
     EvaluateAtIndex,
     FieldAverage,
     Frame,
-    Math,
-    MatrixSVD,
     Switch,
 )
 

--- a/src/nodebpy/nodes/geometry/groups.py
+++ b/src/nodebpy/nodes/geometry/groups.py
@@ -192,12 +192,10 @@ class PrincipalComponents(CustomGeometryGroup):
                     axis2 >> matrix.i[int(i * 4 + j)]
 
         with Frame("SVD"):
-            svd = MatrixSVD(matrix)
-            svd.o.s >> out_princ
-            long, inter, short = [
-                CombineXYZ(*svd.o.u[i * 4 : (i * 4) + 3]) for i in range(3)
-            ]
+            u, s, v = matrix.o.matrix.svd()
+            s >> out_princ
+            long, inter, short = [CombineXYZ(*u[i * 4 : (i * 4) + 3]) for i in range(3)]
             long >> out_long
             short >> out_short
             AxesToRotation(long, short) >> out_rotation
-            (inter * Math.sign(svd.o.u.determinant())) >> out_inter
+            inter * u.determinant().sign() >> out_inter

--- a/src/nodebpy/nodes/geometry/manual.py
+++ b/src/nodebpy/nodes/geometry/manual.py
@@ -406,7 +406,7 @@ class Switch(BaseNode, Generic[_T]):
     def input_type(
         self,
     ) -> _SwitchDataTypes:
-        return self.node.input_type  # ty: ignore[invalid-return-type]
+        return self.node.input_type
 
     @input_type.setter
     def input_type(

--- a/tests/test_builder_coverage.py
+++ b/tests/test_builder_coverage.py
@@ -274,7 +274,7 @@ def test_boolean_mixin_operators(op, expected_op):
         raw_sock = g.RandomValue.boolean(0.5).node.outputs[0]
         bool_sock = BooleanSocket(raw_sock)
         result = (bool_sock | True) if op == "or" else (bool_sock & True)
-    assert result.operation == expected_op
+    assert result.node.operation == expected_op
 
 
 def test_color_separate_in_compositor_tree():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -52,12 +52,12 @@ def test_geometry_scalar_sockets():
     assert isinstance(f, Socket)
     assert isinstance(i, Socket)
     assert isinstance(b, Socket)
-    assert f.interface_socket.name == "Value"
-    assert i.interface_socket.name == "Count"
-    assert b.interface_socket.name == "Enabled"
-    assert f.interface_socket.default_value == pytest.approx(2.5)
-    assert i.interface_socket.default_value == 4
-    assert b.interface_socket.default_value is True
+    assert f._interface_socket.name == "Value"
+    assert i._interface_socket.name == "Count"
+    assert b._interface_socket.name == "Enabled"
+    assert f._interface_socket.default_value == pytest.approx(2.5)
+    assert i._interface_socket.default_value == 4
+    assert b._interface_socket.default_value is True
 
 
 def test_geometry_vector_sockets():
@@ -67,28 +67,28 @@ def test_geometry_vector_sockets():
         r = tree.inputs.rotation("Rotation")
         m = tree.inputs.matrix("Transform")
 
-    assert v.interface_socket.name == "Direction"
-    assert r.interface_socket.name == "Rotation"
-    assert m.interface_socket.name == "Transform"
-    assert v.interface_socket.socket_type == "NodeSocketVector"
-    assert r.interface_socket.socket_type == "NodeSocketRotation"
-    assert m.interface_socket.socket_type == "NodeSocketMatrix"
+    assert v._interface_socket.name == "Direction"
+    assert r._interface_socket.name == "Rotation"
+    assert m._interface_socket.name == "Transform"
+    assert v._interface_socket.socket_type == "NodeSocketVector"
+    assert r._interface_socket.socket_type == "NodeSocketRotation"
+    assert m._interface_socket.socket_type == "NodeSocketMatrix"
 
 
 def test_geometry_string_socket():
     with g.tree(arrange=None) as tree:
         ss = tree.inputs.string("Label", default_value="hello")
 
-    assert ss.interface_socket.name == "Label"
-    assert ss.interface_socket.default_value == "hello"
+    assert ss._interface_socket.name == "Label"
+    assert ss._interface_socket.default_value == "hello"
 
 
 def test_geometry_menu_socket():
     with g.tree(arrange=None) as tree:
         menu = tree.inputs.menu("Mode")
 
-    assert menu.interface_socket.name == "Mode"
-    assert menu.interface_socket.socket_type == "NodeSocketMenu"
+    assert menu._interface_socket.name == "Mode"
+    assert menu._interface_socket.socket_type == "NodeSocketMenu"
 
 
 def test_geometry_datablock_sockets():
@@ -99,10 +99,10 @@ def test_geometry_datablock_sockets():
         mat = tree.inputs.material("Material")
         img = tree.inputs.image("Image")
 
-    assert obj.interface_socket.socket_type == "NodeSocketObject"
-    assert col.interface_socket.socket_type == "NodeSocketCollection"
-    assert mat.interface_socket.socket_type == "NodeSocketMaterial"
-    assert img.interface_socket.socket_type == "NodeSocketImage"
+    assert obj._interface_socket.socket_type == "NodeSocketObject"
+    assert col._interface_socket.socket_type == "NodeSocketCollection"
+    assert mat._interface_socket.socket_type == "NodeSocketMaterial"
+    assert img._interface_socket.socket_type == "NodeSocketImage"
 
 
 def test_geometry_bundle_and_closure_sockets():
@@ -110,17 +110,17 @@ def test_geometry_bundle_and_closure_sockets():
         bundle = tree.inputs.bundle("Bundle")
         closure = tree.inputs.closure("Closure")
 
-    assert bundle.interface_socket.socket_type == "NodeSocketBundle"
-    assert closure.interface_socket.socket_type == "NodeSocketClosure"
+    assert bundle._interface_socket.socket_type == "NodeSocketBundle"
+    assert closure._interface_socket.socket_type == "NodeSocketClosure"
 
 
 def test_geometry_color_socket():
     with g.tree(arrange=None) as tree:
         col = tree.inputs.color("Tint", (0.5, 0.1, 0.9, 1.0))
 
-    assert col.interface_socket.name == "Tint"
-    assert col.interface_socket.default_value[0] == pytest.approx(0.5)
-    assert col.interface_socket.default_value[2] == pytest.approx(0.9)
+    assert col._interface_socket.name == "Tint"
+    assert col._interface_socket.default_value[0] == pytest.approx(0.5)
+    assert col._interface_socket.default_value[2] == pytest.approx(0.9)
 
 
 # ---------------------------------------------------------------------------
@@ -138,19 +138,19 @@ def test_float_subtype_and_limits():
             subtype="FACTOR",
         )
 
-    assert f.interface_socket.default_value == pytest.approx(0.5)
-    assert f.interface_socket.min_value == pytest.approx(0.0)
-    assert f.interface_socket.max_value == pytest.approx(1.0)
-    assert f.interface_socket.subtype == "FACTOR"
+    assert f._interface_socket.default_value == pytest.approx(0.5)
+    assert f._interface_socket.min_value == pytest.approx(0.0)
+    assert f._interface_socket.max_value == pytest.approx(1.0)
+    assert f._interface_socket.subtype == "FACTOR"
 
 
 def test_integer_limits():
     with g.tree(arrange=None) as tree:
         i = tree.inputs.integer("Count", default_value=10, min_value=1, max_value=100)
 
-    assert i.interface_socket.default_value == 10
-    assert i.interface_socket.min_value == 1
-    assert i.interface_socket.max_value == 100
+    assert i._interface_socket.default_value == 10
+    assert i._interface_socket.min_value == 1
+    assert i._interface_socket.max_value == 100
 
 
 def test_socket_description():
@@ -158,8 +158,8 @@ def test_socket_description():
         geo = tree.inputs.geometry("Geometry", description="The input mesh")
         f = tree.inputs.float("Scale", description="Uniform scale factor")
 
-    assert geo.interface_socket.description == "The input mesh"
-    assert f.interface_socket.description == "Uniform scale factor"
+    assert geo._interface_socket.description == "The input mesh"
+    assert f._interface_socket.description == "Uniform scale factor"
 
 
 def test_socket_vector_default_input():
@@ -168,8 +168,8 @@ def test_socket_vector_default_input():
         normal = tree.inputs.vector("Normal", default_input="NORMAL")
         out = tree.outputs.vector()
 
-    assert pos.interface_socket.default_input == "POSITION"
-    assert normal.interface_socket.default_input == "NORMAL"
+    assert pos._interface_socket.default_input == "POSITION"
+    assert normal._interface_socket.default_input == "NORMAL"
     assert out._default_input_socket == out.socket
 
 
@@ -178,29 +178,29 @@ def test_socket_hide_value():
         f = tree.inputs.float("Hidden", hide_value=True)
         i = tree.inputs.integer("Visible")
 
-    assert f.interface_socket.hide_value is True
-    assert i.interface_socket.hide_value is False
+    assert f._interface_socket.hide_value is True
+    assert i._interface_socket.hide_value is False
 
 
 def test_socket_menu_expanded():
     with g.tree(arrange=None) as tree:
         menu = tree.inputs.menu("Mode", expanded=True)
 
-    assert menu.interface_socket.menu_expanded is True
+    assert menu._interface_socket.menu_expanded is True
 
 
 def test_integer_percentage_subtype():
     with g.tree(arrange=None) as tree:
         pct = tree.inputs.integer("Progress", default_value=50, subtype="PERCENTAGE")
 
-    assert pct.interface_socket.subtype == "PERCENTAGE"
+    assert pct._interface_socket.subtype == "PERCENTAGE"
 
 
 def test_socket_vector_subtype():
     with g.tree(arrange=None) as tree:
         vel = tree.inputs.vector("Velocity", subtype="VELOCITY")
 
-    assert vel.interface_socket.subtype == "VELOCITY"
+    assert vel._interface_socket.subtype == "VELOCITY"
 
 
 # ---------------------------------------------------------------------------
@@ -214,10 +214,10 @@ def test_geometry_output_sockets():
         f_out = tree.outputs.float("Score")
         b_out = tree.outputs.boolean("Valid")
 
-    assert geo_out.interface_socket.in_out == "OUTPUT"
-    assert f_out.interface_socket.in_out == "OUTPUT"
-    assert b_out.interface_socket.in_out == "OUTPUT"
-    assert f_out.interface_socket.name == "Score"
+    assert geo_out._interface_socket.in_out == "OUTPUT"
+    assert f_out._interface_socket.in_out == "OUTPUT"
+    assert b_out._interface_socket.in_out == "OUTPUT"
+    assert f_out._interface_socket.name == "Score"
 
 
 def test_input_and_output_same_name_independent():
@@ -226,9 +226,9 @@ def test_input_and_output_same_name_independent():
         geo_in = tree.inputs.geometry("Geometry")
         geo_out = tree.outputs.geometry("Geometry")
 
-    assert geo_in.interface_socket.in_out == "INPUT"
-    assert geo_out.interface_socket.in_out == "OUTPUT"
-    assert geo_in.interface_socket is not geo_out.interface_socket
+    assert geo_in._interface_socket.in_out == "INPUT"
+    assert geo_out._interface_socket.in_out == "OUTPUT"
+    assert geo_in._interface_socket is not geo_out._interface_socket
 
 
 # ---------------------------------------------------------------------------
@@ -265,7 +265,7 @@ def test_geometry_float_socket_in_expression():
             >> out
         )
 
-    assert scale.interface_socket.default_value == pytest.approx(2.0)
+    assert scale._interface_socket.default_value == pytest.approx(2.0)
 
 
 def test_multiple_sockets_link_independently():
@@ -277,8 +277,8 @@ def test_multiple_sockets_link_independently():
 
         g.SetPosition(geo, offset=offset) >> out
 
-    assert geo.interface_socket.name == "Geometry"
-    assert offset.interface_socket.name == "Offset"
+    assert geo._interface_socket.name == "Geometry"
+    assert offset._interface_socket.name == "Offset"
 
 
 # ---------------------------------------------------------------------------
@@ -355,10 +355,10 @@ def test_shader_interface_basic():
         )
         prin >> shader_out
 
-    assert shader_out.interface_socket.in_out == "OUTPUT"
-    assert shader_out.interface_socket.socket_type == "NodeSocketShader"
-    assert base_color.interface_socket.default_value[0] == pytest.approx(0.8)
-    assert metallic.interface_socket.max_value == pytest.approx(1.0)
+    assert shader_out._interface_socket.in_out == "OUTPUT"
+    assert shader_out._interface_socket.socket_type == "NodeSocketShader"
+    assert base_color._interface_socket.default_value[0] == pytest.approx(0.8)
+    assert metallic._interface_socket.max_value == pytest.approx(1.0)
 
 
 def test_shader_vector_input():
@@ -369,8 +369,8 @@ def test_shader_vector_input():
 
         s.PrincipledBSDF(normal=normal) >> shader_out
 
-    assert normal.interface_socket.socket_type == "NodeSocketVector"
-    assert normal.interface_socket.name == "Normal"
+    assert normal._interface_socket.socket_type == "NodeSocketVector"
+    assert normal._interface_socket.name == "Normal"
 
 
 def test_shader_int_and_boolean_inputs():
@@ -381,9 +381,9 @@ def test_shader_int_and_boolean_inputs():
 
         s.PrincipledBSDF() >> shader_out
 
-    assert samples.interface_socket.default_value == 128
-    assert samples.interface_socket.min_value == 1
-    assert enabled.interface_socket.default_value is True
+    assert samples._interface_socket.default_value == 128
+    assert samples._interface_socket.min_value == 1
+    assert enabled._interface_socket.default_value is True
 
 
 def test_shader_float_output():
@@ -394,8 +394,8 @@ def test_shader_float_output():
         prin = s.PrincipledBSDF()
         prin >> shader_out
 
-    assert alpha_out.interface_socket.in_out == "OUTPUT"
-    assert alpha_out.interface_socket.socket_type == "NodeSocketFloat"
+    assert alpha_out._interface_socket.in_out == "OUTPUT"
+    assert alpha_out._interface_socket.socket_type == "NodeSocketFloat"
 
 
 # ---------------------------------------------------------------------------
@@ -413,9 +413,9 @@ def test_compositor_color_and_float_sockets():
 
         c.Mix.color(fac, image, c.Blur(image)) >> out
 
-    assert image.interface_socket.socket_type == "NodeSocketColor"
-    assert fac.interface_socket.default_value == pytest.approx(1.0)
-    assert out.interface_socket.in_out == "OUTPUT"
+    assert image._interface_socket.socket_type == "NodeSocketColor"
+    assert fac._interface_socket.default_value == pytest.approx(1.0)
+    assert out._interface_socket.in_out == "OUTPUT"
 
 
 def test_compositor_vector_socket():
@@ -425,7 +425,7 @@ def test_compositor_vector_socket():
 
         c.Blur(normal) >> out
 
-    assert normal.interface_socket.socket_type == "NodeSocketVector"
+    assert normal._interface_socket.socket_type == "NodeSocketVector"
 
 
 def test_compositor_menu_socket():
@@ -436,8 +436,8 @@ def test_compositor_menu_socket():
 
         c.Blur(image) >> out
 
-    assert mode.interface_socket.socket_type == "NodeSocketMenu"
-    assert mode.interface_socket.menu_expanded is True
+    assert mode._interface_socket.socket_type == "NodeSocketMenu"
+    assert mode._interface_socket.menu_expanded is True
 
 
 def test_compositor_multiple_outputs():
@@ -448,10 +448,10 @@ def test_compositor_multiple_outputs():
 
         c.Blur(image) >> image_out
 
-    assert image_out.interface_socket.in_out == "OUTPUT"
-    assert mask_out.interface_socket.in_out == "OUTPUT"
-    assert image_out.interface_socket.socket_type == "NodeSocketColor"
-    assert mask_out.interface_socket.socket_type == "NodeSocketFloat"
+    assert image_out._interface_socket.in_out == "OUTPUT"
+    assert mask_out._interface_socket.in_out == "OUTPUT"
+    assert image_out._interface_socket.socket_type == "NodeSocketColor"
+    assert mask_out._interface_socket.socket_type == "NodeSocketFloat"
 
 
 def test_compositor_int_and_boolean_sockets():
@@ -463,9 +463,9 @@ def test_compositor_int_and_boolean_sockets():
         image = tree.inputs.color("Image")
         c.Blur(image) >> out
 
-    assert size.interface_socket.default_value == 3
-    assert size.interface_socket.min_value == 1
-    assert enabled.interface_socket.socket_type == "NodeSocketBool"
+    assert size._interface_socket.default_value == 3
+    assert size._interface_socket.min_value == 1
+    assert enabled._interface_socket.socket_type == "NodeSocketBool"
 
 
 def test_compositor_panel_with_socket_methods():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -649,6 +649,9 @@ def test_color_socket_input_shader():
         for i, axis in enumerate(sep.i.color):
             s.Value(i) >> axis
 
+        with pytest.raises(TypeError):
+            sep.i.color.a
+
     assert sep.i.color.links[0].from_node
     assert sep.i.color.links[0].from_node.bl_idname == s.CombineColor._bl_idname
 
@@ -697,8 +700,8 @@ def test_matrix_socket_input_indexing():
                 assert input.links[0].from_node == val.node
             else:
                 assert not input.links
-            input.socket.default_value = i  # ty: ignore[unresolved-attribute]
-            assert input.socket.default_value == i  # ty: ignore[unresolved-attribute]
+            input.socket.default_value = i
+            assert input.socket.default_value == i
 
     transform_input = transform.node.inputs["Transform"]
     assert transform_input.links
@@ -721,7 +724,7 @@ def test_matrix_socket_input_slice():
         components = transform.i.transform[0:3]
 
     assert len(components) == 3
-    combine_node = transform.node.inputs["Transform"].links[0].from_node  # ty: ignore[not-subscriptable]
+    combine_node = transform.node.inputs["Transform"].links[0].from_node
     assert combine_node
     assert combine_node.bl_idname == g.CombineMatrix._bl_idname
 
@@ -752,10 +755,9 @@ def test_accessor_rotation():
         quat = g.RotationToQuaternion(rot.o.rotation)
         assert quat.i[0].links
         rot_to_quat = quat.i[0].links[0].from_node
-        assert quat.o.w.node.inputs[0].links[0].from_node == rot_to_quat  # ty: ignore[not-subscriptable]
-        assert quat.o.x.node.inputs[0].links[0].from_node == rot_to_quat  # ty: ignore[not-subscriptable]
-        assert quat.o.y.node.inputs[0].links[0].from_node == rot_to_quat  # ty: ignore[not-subscriptable]
-        assert quat.o.z.node.inputs[0].links[0].from_node == rot_to_quat  # ty: ignore[not-subscriptable]
+        assert all(
+            axis.node.inputs[0].links[0].from_node == rot_to_quat for axis in quat.o
+        )
 
         eul = rot.o.rotation.euler()
         assert isinstance(eul, VectorSocket)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -603,14 +603,19 @@ def test_vector_socket_input_indexing_reuse():
 def test_vector_socket_output_iteration():
     """Iterating an output VectorSocket yields X, Y, Z via a single SeparateXYZ."""
     with g.tree():
-        vec = g.Position()
-        components = list(vec.o.position)
+        pos = g.Position().o.position
+        components = list(pos)
+        assert pos[2].name == "Z"
+        assert all(isinstance(x, FloatSocket) for x in pos)
+        assert all(isinstance(x, FloatSocket) for x in pos[:2])
 
     assert len(components) == 3
     sep_node = components[0].socket.node
     assert sep_node
     assert sep_node.bl_idname == g.SeparateXYZ._bl_idname
     assert all(c.socket.node == sep_node for c in components)
+    assert not pos._is_compositor_tree
+    assert not pos._is_shader_tree
 
 
 def test_vector_socket_output_len():
@@ -652,19 +657,27 @@ def test_color_socket_input_shader():
         with pytest.raises(TypeError):
             sep.i.color.a
 
+        comb = s.CombineColor()
+        with pytest.raises(TypeError):
+            comb.o.color.a
+
+        assert len(comb.o.color) == 3
+
     assert sep.i.color.links[0].from_node
     assert sep.i.color.links[0].from_node.bl_idname == s.CombineColor._bl_idname
+    assert len(sep.i.color) == 3
 
 
 def test_color_socket_input_compositor():
     with c.tree():
-        sep = c.SeparateColor()
+        image = c.SeparateColor().i.image
 
-        for i, axis in enumerate(sep.i.image):
+        for i, axis in enumerate(image):
             c.Value(i) >> axis
 
-    assert sep.i.image.links[0].from_node
-    assert sep.i.image.links[0].from_node.bl_idname == c.CombineColor._bl_idname
+    assert image.links[0].from_node
+    assert image.links[0].from_node.bl_idname == c.CombineColor._bl_idname
+    assert image._is_compositor_tree
 
 
 def test_color_socket_output_iteration():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -842,8 +842,8 @@ def test_boolean_socket_switches():
             method = name.lower().replace("int", "integer").replace("rgba", "color")
             if method == "shader":
                 continue
-            switch = getattr(i.switch, method)()
-            assert switch.input_type == name
+            sock = getattr(i.switch, method)()
+            assert sock.node.input_type == name
 
 
 def test_vector_socket_methods():
@@ -852,17 +852,17 @@ def test_vector_socket_methods():
         norm = vec.normalize()
         assert isinstance(norm, VectorSocket)
         assert norm.node.bl_idname == g.VectorMath._bl_idname
-        assert norm.node.operation == "NORMALIZE"  # ty: ignore[unresolved-attribute]
+        assert norm.node.operation == "NORMALIZE"
         assert norm.socket == vec.normalize().socket
 
         dot = vec.dot(g.Vector())
         assert isinstance(dot, FloatSocket)
         assert dot.node.bl_idname == g.VectorMath._bl_idname
-        assert dot.node.operation == "DOT_PRODUCT"  # ty: ignore[unresolved-attribute]
+        assert dot.node.operation == "DOT_PRODUCT"
         assert dot.socket != vec.dot(g.Vector()).socket
 
         ln = vec.length()
         assert isinstance(ln, FloatSocket)
         assert ln.node.bl_idname == g.VectorMath._bl_idname
-        assert ln.node.operation == "LENGTH"  # ty: ignore[unresolved-attribute]
+        assert ln.node.operation == "LENGTH"
         assert ln.socket == vec.length().socket

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -859,6 +859,23 @@ def test_boolean_socket_switches():
             assert sock.node.input_type == name
 
 
+def test_float_socket_methods():
+    with g.tree():
+        val = g.Float().o.value
+
+        result = val.sign()
+        assert result.node.bl_idname == g.Math._bl_idname
+        assert result.node.operation == "SIGN"
+
+        result = val.negate()
+        assert result.node.bl_idname == g.Math._bl_idname
+        assert result.node.operation == "MULTIPLY"
+        assert result.node.inputs[1].default_value == pytest.approx(-1.0)
+        assert result.node.inputs[0].links[0].from_node == val.node
+
+        assert len(val.links) == 2
+
+
 def test_vector_socket_methods():
     with g.tree() as tree:
         vec = tree.inputs.vector()

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -662,6 +662,8 @@ def test_color_socket_input_shader():
             comb.o.color.a
 
         assert len(comb.o.color) == 3
+        assert sep.i.color[2].name == "Blue"
+        assert sep.i.color[0].name == "Red"
 
     assert sep.i.color.links[0].from_node
     assert sep.i.color.links[0].from_node.bl_idname == s.CombineColor._bl_idname

--- a/tests/test_usecases.py
+++ b/tests/test_usecases.py
@@ -775,4 +775,4 @@ def test_import_microscopy_volume_node_group():
     links.new(store_transformed_grid.outputs["Volume"], group_output.inputs["Volume"])
     links.new(set_grid_transform.outputs["Grid"], group_output.inputs["Grid"])
 
-    return node_group
+    # return node_group


### PR DESCRIPTION
This adds more methods for some of the individual socket types and properly exposes their types for different math and slicing operations. Additionally adds the `sign()` and `negate()` methods to float sockets.

Below is original discussion on the PR but no longer included.

---


Currently this change also tweaks the return of a math operation to the be the output _socket_ of a math node rather than the node itself. I'm not sold on the change, but out of 400 tests it did only break a single test where I was explicitly checking for the operation of the resulting math node.

Depends on what direction we want the node API to go in. The "Socket-based" is more succinct for simple chains of operations, but becomes before complex to inject more complex behaviour which is why I went with the original "node-first" design to begin with.

Likely won't merge in this PR but will continue to test for the time being. With the robust type checking that we have it should avoid some confusion, but we should come up with some clear "rules" for when a socket is returned vs when a node is returned. Currently don't have a method to 'recover' the `VectorMath` node from a socket, so worth getting that first before we change the methods as well.


```py
result = g.Vector() * g.Vector()

result.o.vector.normalize() # old method, returns the VectorMath node.

result.normalize()          # new method, returns the VectorSocket of the `node
```

