### PR TITLE
Reference the node/builder from a socket

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -5,6 +5,7 @@ title: Changelog
 ## v0.16.0 - UNRELEASED
 
 ### Enhancements
+- Sockets have a reference to the buidler/node that they belong to via `self.builder_node` property.
 - Added `svd()` method onto `MatrixSocket` which returns a `tuple[MatrixSocket, VectorSocket, MatrixSocket]` for the `[u, s, v]` outputs of the `MatrixSVD` node.
 - Add `sign()` and `negate()` methods onto the `FloatSocket` for method chaining. Both return `FloatSocket`.
 - Remove `socket_name` property from `BaseSocket`, already accessible via `.socket.name`.

--- a/src/nodebpy/builder/accessor.py
+++ b/src/nodebpy/builder/accessor.py
@@ -14,6 +14,7 @@ from ._utils import (
 )
 
 if TYPE_CHECKING:
+    from .node import BaseNode
     from .socket import Socket
 
 
@@ -30,9 +31,12 @@ class SocketAccessor:
         self,
         collection: bpy.types.NodeInputs | bpy.types.NodeOutputs | list[NodeSocket],
         direction: Literal["input", "output"],
+        *,
+        builder: BaseNode | None = None,
     ):
         self._direction = direction
         self._collection = collection
+        self._builder = builder
 
     def _index(self, key: str | int) -> int:
         """Find socket index by identifier, falling back to name.
@@ -74,11 +78,18 @@ class SocketAccessor:
     def _get(self, key: str | int | slice) -> "Socket | list[Socket]":
         """Get a Socket for a socket by identifier, name, or index."""
         if isinstance(key, slice):
-            return [
+            sockets = [
                 _get_socket_linker(self._collection[i])
                 for i in range(*key.indices(len(self._collection)))
             ]
-        return _get_socket_linker(self._collection[self._index(key)])
+            if self._builder is not None:
+                for s in sockets:
+                    s._builder_node = self._builder
+            return sockets
+        socket = _get_socket_linker(self._collection[self._index(key)])
+        if self._builder is not None:
+            socket._builder_node = self._builder
+        return socket
 
     @overload
     def __getitem__(self, key: slice) -> "list[Socket]": ...

--- a/src/nodebpy/builder/node.py
+++ b/src/nodebpy/builder/node.py
@@ -21,6 +21,7 @@ from bpy.types import (
     GeometryNodeTree,
     Node,
     NodeSocket,
+    NodeTree,
     ShaderNodeGroup,
     ShaderNodeTree,
 )
@@ -101,8 +102,9 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
 
     @classmethod
     def _from_node(cls, node: Node) -> Self:
-        builder = cls()
-        builder.tree.nodes.remove(builder.node)
+        builder = cls.__new__(cls)
+        builder._tree = TreeBuilder(cast(NodeTree, node.id_data))
+        builder._placeholder_inputs = []
         builder.node = node
         return builder
 
@@ -178,12 +180,12 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
     @property
     def o(self) -> SocketAccessor:
         """Output socket accessor. Subclasses narrow the return type via TYPE_CHECKING."""
-        return SocketAccessor(self.node.outputs, "output")
+        return SocketAccessor(self.node.outputs, "output", builder=self)
 
     @property
     def i(self) -> SocketAccessor:
         """Input socket accessor. Subclasses narrow the return type via TYPE_CHECKING."""
-        return SocketAccessor(self.node.inputs, "input")
+        return SocketAccessor(self.node.inputs, "input", builder=self)
 
 
 class DynamicInputsMixin(ABC):

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -74,6 +74,7 @@ class BaseSocket:
         self._tree = None
         self.socket = socket
         self._interface_socket: bpy.types.NodeTreeInterfaceSocket | None = None
+        self._builder_node: BaseNode | None = None
 
     @property
     def node(self) -> Node:
@@ -138,6 +139,11 @@ class Socket(BaseSocket, _SocketLike, OperatorMixin, LinkingMixin):
         The underlying Blender NodeSocket.
 
     """
+
+    @property
+    def builder_node(self) -> "BaseNode | None":
+        """The builder node that owns this socket, if accessed via .o/.i."""
+        return self._builder_node
 
     # -- Dispatch methods: per-type math logic. --
     # Called by OperatorMixin operators via _get_socket_linker().

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -898,3 +898,23 @@ def test_vector_socket_methods():
         assert ln.node.bl_idname == g.VectorMath._bl_idname
         assert ln.node.operation == "LENGTH"
         assert ln.socket == vec.length().socket
+
+
+def test_socket_builder_reference():
+    with g.tree() as tree:
+        position = g.Position()
+        pos = position.o.position
+        assert pos.builder_node
+        assert pos.builder_node.node == position.node
+
+        _node = pos.builder_node.node
+        del position
+        del pos
+
+        position = g.Position._from_node(_node)
+        assert position.node == _node
+
+        par = g.SplineParameter()
+
+        socks = list(par.o[:2])
+        assert all(s.builder_node.node == par.node for s in socks)


### PR DESCRIPTION
Improves instantiating a Node/Builder once a node already exists. Adds a reference to the node/builder a socket comes from, or ability to instantiate that class if need be.
