### PR TITLE
Refactor socket methods for returning tuples

### DIFF
--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,1 +1,1 @@
-version: 0.16.0
+version: 0.17.0

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -19,7 +19,7 @@ string.contains()    # return g.MatchString().o.result
 string.slice()       # return g.SliceString().o.string
 string.format()      # return g.FormatString().o.string
 string.replace()     # return g.ReplaceString().o.string
-string.find()        # return (g.FindInString().o.first_found, g.FindInString().o.count)
+string.find()        # return FindResult(first_found, count)
 string.join(x)       # return g.JoinStrings(x, delimeter=string)
 ```
 
@@ -70,18 +70,53 @@ pos = g.Position().o.position
 pos.builder_node   # the Position node
 ```
 
-- Added `svd()` method onto `MatrixSocket` which returns a `tuple[MatrixSocket, VectorSocket, MatrixSocket]` for the `[u, s, v]` outputs of the `MatrixSVD` node.
+- Added `svd()` method onto `MatrixSocket` which returns an `SVDResult` with `.u`, `.s`, `.v` properties.
 - Add `sign()` and `negate()` methods onto the `FloatSocket` for method chaining. Both return `FloatSocket`.
 - Remove `socket_name` property from `BaseSocket`, already accessible via `.socket.name`.
 - Added `.dot()`, `.length()` and `.normalize()` methods to `VectorSocket` which create the corresponding `DotProduct`, `VectorLength` and `Normalize` nodes.
 - Properties on sockets that aren't just accessing components of the socket are node methods. They still return sockets and not nodes.
     - `RotationSocket.invert` -> `RotationSocket.invert()`
-    - `RotationSocket.euler` -> `Rotation.euler()`
+    - `RotationSocket.euler` -> `RotationSocket.to_euler()`
     - `MatrixSocket.invert` -> `MatrixSocket.invert()`
     - `MatrixSocket.transpose` -> `MatrixSocket.transpose()`
     - `MatrixSocket.determinant` -> `MatrixSocket.determinant()`
+- New methods on `VectorSocket` for applying transforms:
+    - `rotate(rotation)` — apply a `RotationSocket` via `RotateVector`, returns `VectorSocket`
+    - `transform(matrix)` — apply a `MatrixSocket` via `TransformPoint`, returns `VectorSocket`
+- New methods on `RotationSocket`:
+    - `rotate(rotation, rotation_space="GLOBAL")` — compose rotations via `RotateRotation`, returns `RotationSocket`
+    - `to_euler()` — convert to XYZ euler angles, returns `VectorSocket` (renamed from `euler()`)
+    - `to_quaternion()` — decompose via `RotationToQuaternion`, returns a `Quaternion` with `.w`, `.x`, `.y`, `.z`
+    - `to_axis_angle()` — decompose via `RotationToAxisAngle`, returns an `AxisAngle` with `.axis` and `.angle`
+- `FloatSocket.mix` — factory property for creating typed `Mix` nodes driven by this socket as the factor. Supports `.float()`, `.vector()`, `.color()`, `.rotation()`.
+
+```py
+fac = g.Value(0.5).o.value
+fac.mix.float(0.0, 1.0)          # FloatSocket
+fac.mix.vector((0,0,0), (1,1,1)) # VectorSocket
+fac.mix.color(color_a, color_b)  # ColorSocket
+```
+
+- `FloatSocket.to_integer(rounding_mode="ROUND")` — convert to integer via `FloatToInteger`. Accepts `"ROUND"`, `"FLOOR"`, `"CEILING"`, or `"TRUNCATE"`.
 
 ### Breaking Changes
+- `RotationSocket.euler()` renamed to `RotationSocket.to_euler()` for consistency with the new `to_quaternion()` and `to_axis_angle()` methods.
+- `RotationSocket.w`, `.x`, `.y`, `.z` component properties removed. Use `to_quaternion()` instead.
+- Multi-output socket methods (`to_quaternion()`, `to_axis_angle()`, `find()`, `svd()`) now return typed `NamedTuple` results. Both named access and positional unpacking are fully typed.
+
+```py
+# Named access
+rot.to_quaternion().w      # FloatSocket
+rot.to_axis_angle().angle  # FloatSocket
+string.find("/").first_found  # IntegerSocket
+mat.svd().u                # MatrixSocket
+
+# Positional unpacking — all variables are specifically typed
+w, x, y, z = rot.to_quaternion()
+axis, angle = rot.to_axis_angle()
+first, count = string.find("/")
+u, s, v = mat.svd()
+```
 - `Compare.switch(false, true)` with automatic type inference has been removed. Use the explicit typed factory methods on `BooleanSocket.switch` instead.
 
 ```py

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -1,8 +1,49 @@
 ---
 title: Changelog
 ---
+## v0.17.0 - UNRELEASED
 
-## v0.16.0 - UNRELEASED
+### Enhancements
+- New methods on `VectorSocket` for applying transforms:
+    - `rotate(rotation)` — apply a `RotationSocket` via `RotateVector`, returns `VectorSocket`
+    - `transform(matrix)` — apply a `MatrixSocket` via `TransformPoint`, returns `VectorSocket`
+- New methods on `RotationSocket`:
+    - `rotate(rotation, rotation_space="GLOBAL")` — compose rotations via `RotateRotation`, returns `RotationSocket`
+    - `to_euler()` — convert to XYZ euler angles, returns `VectorSocket` (renamed from `euler()`)
+    - `to_quaternion()` — decompose via `RotationToQuaternion`, returns a `Quaternion` named tuple with `.w`, `.x`, `.y`, `.z`
+    - `to_axis_angle()` — decompose via `RotationToAxisAngle`, returns an `AxisAngle` with `.axis` and `.angle`
+- `FloatSocket.mix` — factory property for creating typed `Mix` nodes driven by this socket as the factor. Supports `.float()`, `.vector()`, `.color()`, `.rotation()`.
+
+```py
+fac = g.Value(0.5).o.value
+fac.mix.float(0.0, 1.0)          # FloatSocket
+fac.mix.vector((0,0,0), (1,1,1)) # VectorSocket
+fac.mix.color(color_a, color_b)  # ColorSocket
+```
+
+### Breaking Changes
+- `RotationSocket.euler()` renamed to `RotationSocket.to_euler()` for consistency with the new `to_quaternion()` and `to_axis_angle()` methods.
+- `RotationSocket.w`, `.x`, `.y`, `.z` component properties removed. Use `to_quaternion()` instead.
+- Multi-output socket methods (`to_quaternion()`, `to_axis_angle()`, `find()`, `svd()`) now return typed `NamedTuple` results. Both named access and positional unpacking are fully typed.
+
+```py
+# Named access
+rot.to_quaternion().w      # FloatSocket
+rot.to_axis_angle().angle  # FloatSocket
+string.find("/").first_found  # IntegerSocket
+mat.svd().u                # MatrixSocket
+
+# Positional unpacking — all variables are specifically typed
+w, x, y, z = rot.to_quaternion()
+axis, angle = rot.to_axis_angle()
+first, count = string.find("/")
+u, s, v = mat.svd()
+```
+
+- `FloatSocket.to_integer(rounding_mode="ROUND")` — convert to integer via `FloatToInteger`. Accepts `"ROUND"`, `"FLOOR"`, `"CEILING"`, or `"TRUNCATE"`.
+
+
+## v0.16.0 - 2026-05-05
 
 ### Enhancements
 - Input `VectorSocket` now properly has the `x`, `y`, `z` attributes through `CombineXYZ` node.
@@ -80,43 +121,8 @@ pos.builder_node   # the Position node
     - `MatrixSocket.invert` -> `MatrixSocket.invert()`
     - `MatrixSocket.transpose` -> `MatrixSocket.transpose()`
     - `MatrixSocket.determinant` -> `MatrixSocket.determinant()`
-- New methods on `VectorSocket` for applying transforms:
-    - `rotate(rotation)` — apply a `RotationSocket` via `RotateVector`, returns `VectorSocket`
-    - `transform(matrix)` — apply a `MatrixSocket` via `TransformPoint`, returns `VectorSocket`
-- New methods on `RotationSocket`:
-    - `rotate(rotation, rotation_space="GLOBAL")` — compose rotations via `RotateRotation`, returns `RotationSocket`
-    - `to_euler()` — convert to XYZ euler angles, returns `VectorSocket` (renamed from `euler()`)
-    - `to_quaternion()` — decompose via `RotationToQuaternion`, returns a `Quaternion` with `.w`, `.x`, `.y`, `.z`
-    - `to_axis_angle()` — decompose via `RotationToAxisAngle`, returns an `AxisAngle` with `.axis` and `.angle`
-- `FloatSocket.mix` — factory property for creating typed `Mix` nodes driven by this socket as the factor. Supports `.float()`, `.vector()`, `.color()`, `.rotation()`.
-
-```py
-fac = g.Value(0.5).o.value
-fac.mix.float(0.0, 1.0)          # FloatSocket
-fac.mix.vector((0,0,0), (1,1,1)) # VectorSocket
-fac.mix.color(color_a, color_b)  # ColorSocket
-```
-
-- `FloatSocket.to_integer(rounding_mode="ROUND")` — convert to integer via `FloatToInteger`. Accepts `"ROUND"`, `"FLOOR"`, `"CEILING"`, or `"TRUNCATE"`.
 
 ### Breaking Changes
-- `RotationSocket.euler()` renamed to `RotationSocket.to_euler()` for consistency with the new `to_quaternion()` and `to_axis_angle()` methods.
-- `RotationSocket.w`, `.x`, `.y`, `.z` component properties removed. Use `to_quaternion()` instead.
-- Multi-output socket methods (`to_quaternion()`, `to_axis_angle()`, `find()`, `svd()`) now return typed `NamedTuple` results. Both named access and positional unpacking are fully typed.
-
-```py
-# Named access
-rot.to_quaternion().w      # FloatSocket
-rot.to_axis_angle().angle  # FloatSocket
-string.find("/").first_found  # IntegerSocket
-mat.svd().u                # MatrixSocket
-
-# Positional unpacking — all variables are specifically typed
-w, x, y, z = rot.to_quaternion()
-axis, angle = rot.to_axis_angle()
-first, count = string.find("/")
-u, s, v = mat.svd()
-```
 - `Compare.switch(false, true)` with automatic type inference has been removed. Use the explicit typed factory methods on `BooleanSocket.switch` instead.
 
 ```py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nodebpy"
-version = "0.16.0"
+version = "0.17.0"
 description = "Build nodes trees in Blender more elegantly with code"
 readme = "README.md"
 authors = [

--- a/src/nodebpy/builder/accessor.py
+++ b/src/nodebpy/builder/accessor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Iterator, Literal, overload
 
 import bpy
 from bpy.types import NodeSocket
@@ -200,7 +200,7 @@ class SocketAccessor:
     def __len__(self) -> int:
         return len(self._items())
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator["Socket"]:
         return iter(self._values())
 
     def __getattr__(self, name: str) -> "Socket":

--- a/src/nodebpy/builder/mixins.py
+++ b/src/nodebpy/builder/mixins.py
@@ -11,7 +11,7 @@ from ._utils import SocketError, _resolve_promotion, _SocketLike
 _RShiftT = TypeVar("_RShiftT")
 
 if TYPE_CHECKING:
-    from ..nodes.geometry import Compare, Math, MultiplyMatrices, TransformPoint
+    from ..nodes.geometry import Compare
     from ..types import InputLinkable
     from .node import BaseNode
     from .socket import (

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -5,7 +5,9 @@ from typing import (
     Any,
     Iterable,
     Iterator,
+    Literal,
     Mapping,
+    NamedTuple,
     cast,
     overload,
 )
@@ -75,6 +77,37 @@ if TYPE_CHECKING:
     from ..nodes.geometry.vector import VectorMath
     from .node import BaseNode
     from .tree import TreeBuilder
+
+
+class Quaternion(NamedTuple):
+    """Quaternion components returned by `RotationSocket.to_quaternion()`."""
+
+    w: "FloatSocket"
+    x: "FloatSocket"
+    y: "FloatSocket"
+    z: "FloatSocket"
+
+
+class AxisAngle(NamedTuple):
+    """Axis-angle components returned by `RotationSocket.to_axis_angle()`."""
+
+    axis: "VectorSocket"
+    angle: "FloatSocket"
+
+
+class FindResult(NamedTuple):
+    """Result of `StringSocket.find()`."""
+
+    first_found: "IntegerSocket"
+    count: "IntegerSocket"
+
+
+class SVDResult(NamedTuple):
+    """SVD components returned by `MatrixSocket.svd()`."""
+
+    u: "MatrixSocket"
+    s: "VectorSocket"
+    v: "MatrixSocket"
 
 
 class BaseSocket:
@@ -306,6 +339,21 @@ class _VectorMixin(BaseSocket):
         The same normalize node is re-used each time unless `new_node=True` where a new `VectorMath` node is created each time.
         """
         return self._vmath.normalize(self.socket).o.vector
+
+    def rotate(
+        self,
+        rotation: InputRotation,
+    ) -> "VectorSocket":
+        "Rotate this vector by the given rotation."
+        from ..nodes.geometry import RotateVector
+
+        return RotateVector(self.socket, rotation).o.vector
+
+    def transform(self, matrix: InputMatrix) -> "VectorSocket":
+        "Transform this vector by the given matrix."
+        from ..nodes.geometry import TransformPoint
+
+        return TransformPoint(self.socket, matrix).o.vector
 
     @property
     def default_value(self) -> list[float]:
@@ -712,7 +760,7 @@ class _BooleanMixin(BaseSocket):
 
 
 class _RotationMixin(BaseSocket):
-    """Rotation-specific properties (.w, .x, .y, .z) via RotationToQuaternion."""
+    """Rotation-specific methods."""
 
     socket: NodeSocketRotation
 
@@ -724,43 +772,73 @@ class _RotationMixin(BaseSocket):
     def default_value(self, value: Euler) -> None:
         self.socket.default_value = value
 
-    @property
-    def _quaternion(self) -> "geometry.RotationToQuaternion":
-        from ..nodes.geometry import RotationToQuaternion
-
-        return RotationToQuaternion._find_or_create_linked(self.socket)
-
-    @property
-    def w(self) -> FloatSocket:
-        "Separate the rotation into a quaternion and return the `w` component"
-        return self._quaternion.o.w
-
-    @property
-    def x(self) -> FloatSocket:
-        "Separate the rotation into a quaternion and return the `x` component"
-        return self._quaternion.o.x
-
-    @property
-    def y(self) -> FloatSocket:
-        "Separate the rotation into a quaternion and return the `y` component"
-        return self._quaternion.o.y
-
-    @property
-    def z(self) -> FloatSocket:
-        "Separate the rotation into a quaternion and return the `z` component"
-        return self._quaternion.o.z
-
-    def euler(self) -> "VectorSocket":
-        "Convert the rotation to an XYZ euler rotation and return `VectorSocket`."
-        from ..nodes.geometry.converter import RotationToEuler
-
-        return RotationToEuler._find_or_create_linked(self.socket).o.euler
-
     def invert(self) -> "RotationSocket":
         "Invert the rotation of the socket."
         from ..nodes.geometry import InvertRotation
 
         return InvertRotation._find_or_create_linked(self.socket).o.rotation
+
+    def rotate(
+        self,
+        rotation: InputRotation,
+        rotation_space: Literal["GLOBAL", "LOCAL"] = "GLOBAL",
+    ) -> "RotationSocket":
+        "Rotate this rotation by the given rotation in the specified rotation space."
+        from ..nodes.geometry import RotateRotation
+
+        return RotateRotation(
+            self.socket, rotation, rotation_space=rotation_space
+        ).o.rotation
+
+    def to_euler(self) -> "VectorSocket":
+        "Convert the rotation to an XYZ euler rotation and return `VectorSocket`."
+        from ..nodes.geometry.converter import RotationToEuler
+
+        return RotationToEuler._find_or_create_linked(self.socket).o.euler
+
+    def to_quaternion(self) -> Quaternion:
+        "Decompose the rotation into quaternion components `(w, x, y, z)`."
+        from ..nodes.geometry import RotationToQuaternion
+
+        o = RotationToQuaternion._find_or_create_linked(self.socket).o
+        return Quaternion(o.w, o.x, o.y, o.z)
+
+    def to_axis_angle(self) -> AxisAngle:
+        "Decompose the rotation into axis-angle components `(axis, angle)`."
+        from ..nodes.geometry import RotationToAxisAngle
+
+        o = RotationToAxisAngle(self.socket).o
+        return AxisAngle(o.axis, o.angle)
+
+
+class _FloatMixDataTypeFactory:
+    """Factory for typed Mix nodes driven by a float factor socket.
+
+    Access via ``FloatSocket.mix``. Each method creates a ``Mix`` node using
+    this socket as the factor and returns the corresponding output socket.
+    """
+
+    def __init__(self, socket: NodeSocket):
+        self._socket = socket
+        from ..nodes.geometry import Mix
+
+        self._mix = Mix
+
+    def float(self, a: InputFloat, b: InputFloat) -> "FloatSocket":
+        "Mix two float values, returning a ``FloatSocket``."
+        return self._mix.float(self._socket, a, b).o.result_float
+
+    def vector(self, a: InputVector, b: InputVector) -> "VectorSocket":
+        "Mix two vectors, returning a ``VectorSocket``."
+        return self._mix.vector(self._socket, a, b).o.result_vector
+
+    def color(self, a: InputColor, b: InputColor) -> "ColorSocket":
+        "Mix two colors, returning a ``ColorSocket``."
+        return self._mix.color(self._socket, a, b).o.result_color
+
+    def rotation(self, a: InputRotation, b: InputRotation) -> "RotationSocket":
+        "Mix two rotations, returning a ``RotationSocket``."
+        return self._mix.rotation(self._socket, a, b).o.result_rotation
 
 
 class _FloatMixin(BaseSocket):
@@ -782,6 +860,11 @@ class _FloatMixin(BaseSocket):
 
         return Math
 
+    @property
+    def mix(self) -> _FloatMixDataTypeFactory:
+        "Create a ``Mix`` node using this socket as the factor."
+        return _FloatMixDataTypeFactory(self.socket)
+
     def sign(self) -> "FloatSocket":
         "Return the sign of the FloatSocket, eithe `-1`, `0` or `1`."
         return self._math.sign(self.socket).o.value
@@ -795,6 +878,14 @@ class _FloatMixin(BaseSocket):
         from ..nodes.geometry import ValueToString
 
         return ValueToString.float(self.socket, decimals).o.string
+
+    def to_integer(
+        self, rounding_mode: Literal["ROUND", "FLOOR", "CEILING", "TRUNCATE"] = "ROUND"
+    ) -> "IntegerSocket":
+        "Convert the `FloatSocket` to an `IntegerSocket` by truncating the decimal part."
+        from ..nodes.geometry import FloatToInteger
+
+        return FloatToInteger(self.socket, rounding_mode=rounding_mode).o.integer
 
 
 class _IntegerMixin(BaseSocket):
@@ -959,15 +1050,12 @@ class _StringMixin(BaseSocket):
 
         return StringLength(self.socket).o.length
 
-    def find(self, search: InputString) -> tuple["IntegerSocket", "IntegerSocket"]:
-        """Find where in a string a pattern occurs.
-
-        Returns a tuple(IntegerSocket, IntegerSocket), corresponding to (index_of_first_match, count_of_matches)."""
+    def find(self, search: InputString) -> FindResult:
+        "Find where in a string a pattern occurs. Returns `(first_found, count)`."
         from ..nodes.geometry import FindInString
 
-        node = FindInString(self.socket, search)
-
-        return (node.o.first_found, node.o.count)
+        o = FindInString(self.socket, search).o
+        return FindResult(o.first_found, o.count)
 
     def join(
         self, strings: Iterable[str | "StringSocket" | NodeSocketString | BaseNode]
@@ -1035,11 +1123,12 @@ class _MatrixMixin(BaseSocket):
 
         return TransposeMatrix._find_or_create_linked(self.socket).o.matrix
 
-    def svd(self) -> tuple[MatrixSocket, VectorSocket, MatrixSocket]:
-        "Compute the 'Single Value Decomposition' and return output sockets of the MatrixSVD node, `tuple[u, s, v]`"
+    def svd(self) -> SVDResult:
+        "Decompose the matrix via SVD. Returns `(u, s, v)`."
         from ..nodes.geometry import MatrixSVD
 
-        return tuple(MatrixSVD(self.socket).o)
+        o = MatrixSVD(self.socket).o
+        return SVDResult(o.u, o.s, o.v)
 
     @overload
     def __getitem__(self, key: slice) -> "list[FloatSocket]": ...

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -1158,10 +1158,12 @@ class _MatrixMixin(BaseSocket):
 
         if self.socket.is_output:
             node = SeparateMatrix._find_or_create_linked(self.socket)
-            return iter(node.o)
+            for i in node.o:
+                yield cast(FloatSocket, i)
         else:
             node = CombineMatrix._find_or_create_linked(self.socket)
-            return iter(node.i)
+            for i in node.i:
+                yield cast(FloatSocket, i)
 
     def __len__(self) -> int:
         return 16

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -70,8 +70,6 @@ if TYPE_CHECKING:
         IntegerMath,
         MatchString,
         Math,
-        MultiplyMatrices,
-        TransformPoint,
     )
     from ..nodes.geometry.manual import Compare
     from ..nodes.geometry.vector import VectorMath
@@ -79,7 +77,7 @@ if TYPE_CHECKING:
     from .tree import TreeBuilder
 
 
-class Quaternion(NamedTuple):
+class QuaternionComponents(NamedTuple):
     """Quaternion components returned by `RotationSocket.to_quaternion()`."""
 
     w: "FloatSocket"
@@ -796,12 +794,12 @@ class _RotationMixin(BaseSocket):
 
         return RotationToEuler._find_or_create_linked(self.socket).o.euler
 
-    def to_quaternion(self) -> Quaternion:
+    def to_quaternion(self) -> QuaternionComponents:
         "Decompose the rotation into quaternion components `(w, x, y, z)`."
         from ..nodes.geometry import RotationToQuaternion
 
         o = RotationToQuaternion._find_or_create_linked(self.socket).o
-        return Quaternion(o.w, o.x, o.y, o.z)
+        return QuaternionComponents(o.w, o.x, o.y, o.z)
 
     def to_axis_angle(self) -> AxisAngle:
         "Decompose the rotation into axis-angle components `(axis, angle)`."

--- a/src/nodebpy/types.py
+++ b/src/nodebpy/types.py
@@ -100,7 +100,7 @@ InputColor = typing.Union[
     InputLinkable,
     "ColorSocket",
 ]
-InputString = typing.Union[str, NodeSocketString, EllipsisType, "StringSocket"]
+InputString = typing.Union[None, str, NodeSocketString, EllipsisType, "StringSocket"]
 InputGeometry = typing.Union[NodeSocketGeometry, InputLinkable, "GeometrySocket"]
 InputObject = typing.Union[NodeSocketObject, Object, InputLinkable, "ObjectSocket"]
 InputMaterial = typing.Union[

--- a/tests/test_builder_coverage.py
+++ b/tests/test_builder_coverage.py
@@ -289,7 +289,6 @@ def test_color_separate_in_compositor_tree():
     assert r is not None
 
 
-
 @pytest.mark.parametrize("component", ["translation", "rotation", "scale"])
 def test_matrix_socket_properties(component):
     """_MatrixMixin .translation/.rotation/.scale via SeparateTransform."""

--- a/tests/test_builder_coverage.py
+++ b/tests/test_builder_coverage.py
@@ -289,22 +289,6 @@ def test_color_separate_in_compositor_tree():
     assert r is not None
 
 
-@pytest.mark.parametrize("component", ["w", "x", "y", "z"])
-def test_rotation_socket_properties(component):
-    """_RotationMixin .w/.x/.y/.z via RotationToQuaternion."""
-    with TreeBuilder("RotProp"):
-        rot_sock = g.AxisAngleToRotation(angle=1.0).o._get("Rotation")
-        assert getattr(rot_sock, component) is not None
-
-
-def test_rotation_socket_cached_link():
-    """_RotationMixin second access reuses existing RotationToQuaternion node."""
-    with TreeBuilder("RotCached"):
-        rot_sock = g.AxisAngleToRotation(angle=1.0).o._get("Rotation")
-        x1 = rot_sock.x
-        x2 = rot_sock.x
-    assert x1 is not None and x2 is not None
-
 
 @pytest.mark.parametrize("component", ["translation", "rotation", "scale"])
 def test_matrix_socket_properties(component):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -7,7 +7,7 @@ from mathutils import Euler
 from nodebpy import compositor as c
 from nodebpy import geometry as g
 from nodebpy import shader as s
-from nodebpy.builder import FloatSocket, IntegerSocket, Socket, VectorSocket
+from nodebpy.builder import FloatSocket, IntegerSocket, RotationSocket, Socket, VectorSocket
 from nodebpy.nodes.compositor import CombineXYZ
 from nodebpy.types import SOCKET_TYPES
 
@@ -775,9 +775,9 @@ def test_accessor_rotation():
             axis.node.inputs[0].links[0].from_node == rot_to_quat for axis in quat.o
         )
 
-        eul = rot.o.rotation.euler()
+        eul = rot.o.rotation.to_euler()
         assert isinstance(eul, VectorSocket)
-        assert eul.node == rot.o.rotation.euler().node
+        assert eul.node == rot.o.rotation.to_euler().node
 
 
 def test_matrix_socket_output_len():
@@ -1041,3 +1041,109 @@ def test_string_socket_methods(snapshot):
 
         assert len(tree) == 22
         assert snapshot == tree._repr_markdown_()
+
+
+def test_vector_socket_rotate():
+    with g.tree():
+        vec = g.Position().o.position
+        rot = g.AlignRotationToVector().o.rotation
+
+        result = vec.rotate(rot)
+
+    assert isinstance(result, VectorSocket)
+    assert result.node.bl_idname == g.RotateVector._bl_idname
+    assert result.builder_node.i.vector.links[0].from_node == vec.node
+    assert result.builder_node.i.rotation.links[0].from_node == rot.node
+
+
+def test_vector_socket_transform():
+    with g.tree():
+        vec = g.Position().o.position
+        mat = g.CombineTransform().o.transform
+
+        result = vec.transform(mat)
+
+    assert isinstance(result, VectorSocket)
+    assert result.node.bl_idname == g.TransformPoint._bl_idname
+    assert result.builder_node.i.vector.links[0].from_node == vec.node
+    assert result.builder_node.i.transform.links[0].from_node == mat.node
+
+
+def test_rotation_socket_rotate():
+    with g.tree():
+        rot = g.AlignRotationToVector().o.rotation
+        result_global = rot.rotate(rot)
+        result_local = rot.rotate(rot, rotation_space="LOCAL")
+
+    assert isinstance(result_global, RotationSocket)
+    assert result_global.node.bl_idname == g.RotateRotation._bl_idname
+    assert result_global.node.rotation_space == "GLOBAL"
+    assert result_local.node.rotation_space == "LOCAL"
+
+
+def test_rotation_socket_to_quaternion():
+    with g.tree():
+        rot = g.AlignRotationToVector().o.rotation
+        w, x, y, z = rot.to_quaternion()
+
+    assert all(isinstance(s, FloatSocket) for s in (w, x, y, z))
+    assert w.node == x.node == y.node == z.node
+    assert w.node.bl_idname == g.RotationToQuaternion._bl_idname
+
+    with g.tree():
+        rot = g.AlignRotationToVector().o.rotation
+        quat = rot.to_quaternion()
+        assert isinstance(quat.w, FloatSocket)
+        assert isinstance(quat.x, FloatSocket)
+
+
+def test_rotation_socket_to_axis_angle():
+    with g.tree():
+        rot = g.AlignRotationToVector().o.rotation
+        axis, angle = rot.to_axis_angle()
+
+    assert isinstance(axis, VectorSocket)
+    assert isinstance(angle, FloatSocket)
+    assert axis.node == angle.node
+    assert axis.node.bl_idname == g.RotationToAxisAngle._bl_idname
+
+    with g.tree():
+        rot = g.AlignRotationToVector().o.rotation
+        aa = rot.to_axis_angle()
+        assert isinstance(aa.axis, VectorSocket)
+        assert isinstance(aa.angle, FloatSocket)
+
+
+def test_float_socket_mix():
+    with g.tree():
+        fac = g.Value(0.5).o.value
+        a = g.Value(1.0).o.value
+        b = g.Value(2.0).o.value
+        result = fac.mix.float(a, b)
+
+    assert isinstance(result, FloatSocket)
+    assert result.node.bl_idname == g.Mix._bl_idname
+    assert result.builder_node.i.factor_float.links[0].from_node == fac.node
+
+    with g.tree():
+        fac = g.Value(0.5).o.value
+        result_v = fac.mix.vector((0, 0, 0), (1, 1, 1))
+        result_r = fac.mix.rotation(
+            g.AlignRotationToVector().o.rotation,
+            g.AlignRotationToVector().o.rotation,
+        )
+
+    assert isinstance(result_v, VectorSocket)
+    assert isinstance(result_r, RotationSocket)
+
+
+def test_float_socket_to_integer():
+    with g.tree():
+        val = g.Value(3.7).o.value
+        result = val.to_integer()
+        result_floor = val.to_integer(rounding_mode="FLOOR")
+
+    assert isinstance(result, IntegerSocket)
+    assert result.node.bl_idname == g.FloatToInteger._bl_idname
+    assert result.node.rounding_mode == "ROUND"
+    assert result_floor.node.rounding_mode == "FLOOR"

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -8,6 +8,7 @@ from nodebpy import compositor as c
 from nodebpy import geometry as g
 from nodebpy import shader as s
 from nodebpy.builder import (
+    ColorSocket,
     FloatSocket,
     IntegerSocket,
     RotationSocket,
@@ -1127,11 +1128,10 @@ def test_float_socket_mix():
         b = g.Value(2.0).o.value
         result = fac.mix.float(a, b)
 
-    assert isinstance(result, FloatSocket)
-    assert result.node.bl_idname == g.Mix._bl_idname
-    assert result.builder_node.i.factor_float.links[0].from_node == fac.node
+        assert isinstance(result, FloatSocket)
+        assert result.node.bl_idname == g.Mix._bl_idname
+        assert result.builder_node.i.factor_float.links[0].from_node == fac.node
 
-    with g.tree():
         fac = g.Value(0.5).o.value
         result_v = fac.mix.vector((0, 0, 0), (1, 1, 1))
         result_r = fac.mix.rotation(
@@ -1139,8 +1139,13 @@ def test_float_socket_mix():
             g.AlignRotationToVector().o.rotation,
         )
 
-    assert isinstance(result_v, VectorSocket)
-    assert isinstance(result_r, RotationSocket)
+        assert isinstance(result_v, VectorSocket)
+        assert isinstance(result_r, RotationSocket)
+
+        result = fac.mix.color(g.Color(), g.Mix.color())
+        assert isinstance(result, ColorSocket)
+        assert result.node.bl_idname == g.Mix._bl_idname
+        assert result.builder_node.i.factor_float.links[0].from_node == fac.node
 
 
 def test_float_socket_to_integer():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -7,7 +7,13 @@ from mathutils import Euler
 from nodebpy import compositor as c
 from nodebpy import geometry as g
 from nodebpy import shader as s
-from nodebpy.builder import FloatSocket, IntegerSocket, RotationSocket, Socket, VectorSocket
+from nodebpy.builder import (
+    FloatSocket,
+    IntegerSocket,
+    RotationSocket,
+    Socket,
+    VectorSocket,
+)
 from nodebpy.nodes.compositor import CombineXYZ
 from nodebpy.types import SOCKET_TYPES
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -510,7 +510,9 @@ class TestComparisonEqualNotEqual:
     def test_comparison_float_socket(self):
         """Test float comparison with socket."""
         with TreeBuilder("TestCompareFloatSocket"):
-            result = (g.Integer(5) == 4).switch.float(g.Value(5.0), g.RandomValue.integer())
+            result = (g.Integer(5) == 4).switch.float(
+                g.Value(5.0), g.RandomValue.integer()
+            )
 
         assert result.node.bl_idname == g.Switch._bl_idname
         assert result.node.input_type == "FLOAT"
@@ -965,11 +967,16 @@ class TestColorSocketOperatorMath:
         assert result6.node.operation == "MULTIPLY"
         assert result7.node.bl_idname == g.VectorMath._bl_idname
         assert result7.node.operation == "POWER"
-        assert result7.builder_node.i.vector_001.default_value == pytest.approx((0.1, 0.1, 0.1))
+        assert result7.builder_node.i.vector_001.default_value == pytest.approx(
+            (0.1, 0.1, 0.1)
+        )
         assert result8.node.bl_idname == g.VectorMath._bl_idname
         assert result8.node.operation == "SCALE"
         assert result8.builder_node.i.vector.links[0].from_node == color.node
-        assert result8.builder_node.i.scale.links[0].from_node.bl_idname == g.Value._bl_idname
+        assert (
+            result8.builder_node.i.scale.links[0].from_node.bl_idname
+            == g.Value._bl_idname
+        )
         assert result9.node.operation == "EQUAL"
         assert result9.node.data_type == "FLOAT"
         assert result10.node.operation == "EQUAL"
@@ -992,4 +999,6 @@ class TestIntegerSocketOperators:
             result2 = result == input
             assert result2.node.bl_idname == c.Math._bl_idname
             assert result2.node.operation == "COMPARE"
-            assert result2.builder_node.i.value_002.default_value == pytest.approx(0.00001)
+            assert result2.builder_node.i.value_002.default_value == pytest.approx(
+                0.00001
+            )

--- a/tests/test_usecases.py
+++ b/tests/test_usecases.py
@@ -561,7 +561,7 @@ def test_import_microscopy_volume_nodebpy_node_group(snapshot):
         volume = include.switch.geometry(None, volume)
         volume >> tree.outputs.geometry("Volume")
         (
-            g.Switch.float(include, None, grid)
+            include.switch.float(None, grid)
             >> tree.outputs.float("Grid", structure_type="GRID")
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1169,7 +1169,7 @@ wheels = [
 
 [[package]]
 name = "nodebpy"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Removes the `wxyz` direct access to behind `to_quaternion().x ...`. Other methods which returned a tuple now return a `NamedTuple` to allow for named access of components _and_ unpacking `sdv().u` etc.
