### PR TITLE
Properly use frames in _repr_markdown()

### DIFF
--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,1 +1,1 @@
-version: 520.0.0
+version: 520.0.1

--- a/docs/comparisons.qmd
+++ b/docs/comparisons.qmd
@@ -3,6 +3,7 @@ title: "Comapring the API"
 subtitle: How does the API compare to other existing solutions?
 ---
 
+
 ## `geonodes`
 
 ### 'Hello World'

--- a/src/nodebpy/diagram.py
+++ b/src/nodebpy/diagram.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import bpy
-from bpy.types import Node
+from bpy.types import Node, NodeTree, NodeSocket
 
 _COLOR_CLASS_MAP = {
     "GEOMETRY": "geometry-node",
@@ -60,7 +60,7 @@ def _node_label(node: Node) -> str:
     return label.replace('"', "'")
 
 
-def _sorted_nodes(node_tree, reroute_names: set) -> list:
+def _sorted_nodes(node_tree: NodeTree, reroute_names: set) -> list[Node]:
     input_nodes = [n for n in node_tree.nodes if "GroupInput" in n.bl_idname]
     output_nodes = [n for n in node_tree.nodes if "GroupOutput" in n.bl_idname]
     regular_nodes = [
@@ -74,7 +74,9 @@ def _sorted_nodes(node_tree, reroute_names: set) -> list:
     return input_nodes + sorted_regular + output_nodes
 
 
-def _trace_reroute(node_tree, node, socket):
+def _trace_reroute(
+    node_tree: NodeTree, node: Node, socket: NodeSocket
+) -> tuple[Node, NodeSocket]:
     """Follow a reroute chain backward to the real source node and socket."""
     while node.bl_idname == "NodeReroute":
         input_links = [link for link in node_tree.links if link.to_node == node]
@@ -102,13 +104,43 @@ def to_mermaid(tree) -> str:
 
     lines = ["```{mermaid}", "graph LR"]
 
-    node_map = {}
-    for i, node in enumerate(sorted_nodes):
-        node_id = f"N{i}"
-        node_map[node.name] = node_id
-        label = _node_label(node)
-        css_class = _node_css_class(node)
-        lines.append(f'    {node_id}("{label}"):::{css_class}')
+    node_map: dict[str, str] = {}
+
+    # Assign a stable id to every non-frame node up front so edges resolve
+    # regardless of how nodes are nested inside frames.
+    for i, node in enumerate(n for n in sorted_nodes if n.bl_idname != "NodeFrame"):
+        node_map[node.name] = f"N{i}"
+
+    # A NodeFrame is itself a node; its members point back at it via
+    # `node.parent`. Group children by their parent frame and collect the
+    # top-level (unparented) nodes to start rendering from.
+    frame_ids: dict[str, str] = {
+        node.name: f"F{i}"
+        for i, node in enumerate(n for n in sorted_nodes if n.bl_idname == "NodeFrame")
+    }
+
+    children: dict[str, list[Node]] = {}
+    roots: list[Node] = []
+    for node in sorted_nodes:
+        if node.parent is not None:
+            children.setdefault(node.parent.name, []).append(node)
+        else:
+            roots.append(node)
+
+    def _emit(node: Node, indent: str) -> None:
+        if node.bl_idname == "NodeFrame":
+            title = (node.label or node.name).replace('"', "'")
+            lines.append(f'{indent}subgraph {frame_ids[node.name]}["{title}"]')
+            for child in children.get(node.name, []):
+                _emit(child, indent + "    ")
+            lines.append(f"{indent}end")
+        else:
+            label = _node_label(node)
+            css_class = _node_css_class(node)
+            lines.append(f'{indent}{node_map[node.name]}("{label}"):::{css_class}')
+
+    for node in roots:
+        _emit(node, "    ")
 
     seen_edges = set()
     for link in node_tree.links:

--- a/tests/__snapshots__/test_compositor.ambr
+++ b/tests/__snapshots__/test_compositor.ambr
@@ -4,28 +4,31 @@
   ```{mermaid}
   graph LR
       N0("Group Input"):::default-node
-      N1("Math<br/><small>(SUBTRACT)</small>"):::converter-node
-      N2("Filter"):::default-node
-      N3("Filter"):::default-node
-      N4("Math<br/><small>(DIVIDE)</small>"):::converter-node
-      N5("Math<br/><small>(POWER)</small>"):::converter-node
-      N6("Math<br/><small>(GREATER_THAN)</small>"):::converter-node
-      N7("Math<br/><small>(GREATER_THAN)</small>"):::converter-node
-      N8("Kuwahara"):::default-node
-      N9("Math<br/><small>(ADD)</small>"):::converter-node
-      N10("Mix<br/><small>(0.5,0.5,0.5)</small>"):::default-node
-      N11("Anti-Aliasing"):::default-node
-      N12("Math<br/><small>(SUBTRACT)</small>"):::converter-node
-      N13("Frame"):::default-node
-      N14("Frame"):::default-node
-      N15("Frame"):::default-node
-      N16("Dilate/Erode"):::default-node
-      N17("Anti-Aliasing"):::default-node
-      N18("Alpha Over"):::default-node
-      N19("Menu Switch"):::converter-node
-      N20("Alpha Over"):::default-node
-      N21("Menu Switch"):::converter-node
-      N22("Group Output"):::default-node
+      subgraph F0["Ambient Occlusion"]
+          N1("Math<br/><small>(SUBTRACT)</small>"):::converter-node
+          N5("Math<br/><small>(POWER)</small>"):::converter-node
+          N8("Kuwahara"):::default-node
+          N10("Mix<br/><small>(0.5,0.5,0.5)</small>"):::default-node
+      end
+      subgraph F1["Outline"]
+          N2("Filter"):::default-node
+          N3("Filter"):::default-node
+          N4("Math<br/><small>(DIVIDE)</small>"):::converter-node
+          N6("Math<br/><small>(GREATER_THAN)</small>"):::converter-node
+          N7("Math<br/><small>(GREATER_THAN)</small>"):::converter-node
+          N9("Math<br/><small>(ADD)</small>"):::converter-node
+          N11("Anti-Aliasing"):::default-node
+          N12("Math<br/><small>(SUBTRACT)</small>"):::converter-node
+          N13("Dilate/Erode"):::default-node
+          N14("Anti-Aliasing"):::default-node
+      end
+      subgraph F2["Final Composit"]
+          N15("Alpha Over"):::default-node
+          N16("Menu Switch"):::converter-node
+          N17("Alpha Over"):::default-node
+          N18("Menu Switch"):::converter-node
+      end
+      N19("Group Output"):::default-node
       N0 -->|"AO->Value"| N1
       N1 -->|"Value->Value"| N5
       N5 -->|"Value->Image"| N8
@@ -40,21 +43,21 @@
       N6 -->|"Value->Value"| N9
       N7 -->|"Value->Value"| N9
       N9 -->|"Value->Image"| N11
-      N12 -->|"Value->Size"| N16
-      N11 -->|"Image->Mask"| N16
-      N16 -->|"Mask->Image"| N17
-      N17 -->|"Image->Background"| N18
-      N18 -->|"Image->Outline"| N19
-      N19 -->|"Output->Foreground"| N20
-      N20 -->|"Image->Image"| N21
-      N21 -->|"Output->Image"| N22
-      N0 -->|"Background->Menu"| N21
-      N0 -->|"Background Color->Background"| N20
-      N0 -->|"Outline->Menu"| N19
+      N12 -->|"Value->Size"| N13
+      N11 -->|"Image->Mask"| N13
+      N13 -->|"Mask->Image"| N14
+      N14 -->|"Image->Background"| N15
+      N15 -->|"Image->Outline"| N16
+      N16 -->|"Output->Foreground"| N17
+      N17 -->|"Image->Image"| N18
+      N18 -->|"Output->Image"| N19
+      N0 -->|"Background->Menu"| N18
+      N0 -->|"Background Color->Background"| N17
+      N0 -->|"Outline->Menu"| N16
       N0 -->|"Outline Size->Value"| N12
-      N0 -->|"Outline Color->Foreground"| N18
-      N10 -->|"Result->None"| N19
-      N19 -->|"Output->Output"| N21
+      N0 -->|"Outline Color->Foreground"| N15
+      N10 -->|"Result->None"| N16
+      N16 -->|"Output->Output"| N18
   ```
   '''
 # ---

--- a/tests/__snapshots__/test_diagram.ambr
+++ b/tests/__snapshots__/test_diagram.ambr
@@ -208,6 +208,22 @@
   ```
   '''
 # ---
+# name: test_diagram_frame
+  '''
+  ```{mermaid}
+  graph LR
+      N0("Group Input"):::default-node
+      subgraph F0["Transform"]
+          N1("Set Position"):::geometry-node
+          N2("Transform Geometry"):::geometry-node
+      end
+      N3("Group Output"):::default-node
+      N0 -->|"Geometry->Geometry"| N1
+      N1 -->|"Geometry->Geometry"| N2
+      N2 -->|"Geometry->Geometry"| N3
+  ```
+  '''
+# ---
 # name: test_diagram_join_geometry
   '''
   ```{mermaid}
@@ -234,6 +250,24 @@
       N0 -->|"Value->Value"| N1
       N1 -->|"Value->Value"| N2
       N2 -->|"Value->Result"| N3
+  ```
+  '''
+# ---
+# name: test_diagram_nested_frames
+  '''
+  ```{mermaid}
+  graph LR
+      N0("Group Input"):::default-node
+      subgraph F0["Outer"]
+          N1("Set Position"):::geometry-node
+          subgraph F1["Inner"]
+              N2("Transform Geometry"):::geometry-node
+          end
+      end
+      N3("Group Output"):::default-node
+      N0 -->|"Geometry->Geometry"| N1
+      N1 -->|"Geometry->Geometry"| N2
+      N2 -->|"Geometry->Geometry"| N3
   ```
   '''
 # ---

--- a/tests/__snapshots__/test_usecases.ambr
+++ b/tests/__snapshots__/test_usecases.ambr
@@ -231,16 +231,17 @@
       N0("Group Input"):::default-node
       N1("Format String"):::converter-node
       N2("Import VDB"):::input-node
-      N3("Get Named Grid"):::geometry-node
-      N4("Frame"):::default-node
-      N5("Map Range<br/><small>(4,4,4)</small>"):::converter-node
-      N6("Math<br/><small>(MULTIPLY)</small>"):::converter-node
-      N7("Switch"):::converter-node
-      N8("Set Grid Transform"):::geometry-node
-      N9("Store Named Grid"):::geometry-node
+      subgraph F0["Normalize Grid"]
+          N3("Get Named Grid"):::geometry-node
+          N4("Map Range<br/><small>(4,4,4)</small>"):::converter-node
+          N5("Math<br/><small>(MULTIPLY)</small>"):::converter-node
+          N6("Switch"):::converter-node
+          N7("Set Grid Transform"):::geometry-node
+      end
+      N8("Store Named Grid"):::geometry-node
+      N9("Switch"):::converter-node
       N10("Switch"):::converter-node
-      N11("Switch"):::converter-node
-      N12("Group Output"):::default-node
+      N11("Group Output"):::default-node
       N0 -->|"template_str->Format"| N1
       N0 -->|"cache_dir->cache_dir"| N1
       N0 -->|"dataset_hash->dataset_has"| N1
@@ -252,26 +253,26 @@
       N0 -->|"Frame->t"| N1
       N1 -->|"String->Path"| N2
       N2 -->|"Volume->Volume"| N3
-      N3 -->|"Grid->Value"| N5
-      N5 -->|"Result->Value"| N6
-      N6 -->|"Value->False"| N7
-      N5 -->|"Result->True"| N7
-      N7 -->|"Output->Grid"| N8
-      N8 -->|"Grid->Grid"| N9
-      N9 -->|"Volume->True"| N11
-      N11 -->|"Output->Volume"| N12
-      N8 -->|"Grid->True"| N10
+      N3 -->|"Grid->Value"| N4
+      N4 -->|"Result->Value"| N5
+      N5 -->|"Value->False"| N6
+      N4 -->|"Result->True"| N6
+      N6 -->|"Output->Grid"| N7
+      N7 -->|"Grid->Grid"| N8
+      N8 -->|"Volume->True"| N10
+      N10 -->|"Output->Volume"| N11
+      N7 -->|"Grid->True"| N9
       N0 -->|"Grid Name->Name"| N3
-      N0 -->|"Grid Name->Name"| N9
+      N0 -->|"Grid Name->Name"| N8
+      N0 -->|"Include->Switch"| N9
       N0 -->|"Include->Switch"| N10
-      N0 -->|"Include->Switch"| N11
-      N0 -->|"Normalized->Switch"| N7
-      N0 -->|"VDB Minimum->From Min"| N5
-      N0 -->|"VDB Maximum->From Max"| N5
-      N0 -->|"Original Maximum->Value"| N6
-      N0 -->|"Channel Affine Matrix->Transform"| N8
-      N2 -->|"Volume->Volume"| N9
-      N10 -->|"Output->Grid"| N12
+      N0 -->|"Normalized->Switch"| N6
+      N0 -->|"VDB Minimum->From Min"| N4
+      N0 -->|"VDB Maximum->From Max"| N4
+      N0 -->|"Original Maximum->Value"| N5
+      N0 -->|"Channel Affine Matrix->Transform"| N7
+      N2 -->|"Volume->Volume"| N8
+      N9 -->|"Output->Grid"| N11
   ```
   '''
 # ---

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -129,6 +129,33 @@ def test_diagram_reroute_dedup(snapshot):
     assert snapshot == to_mermaid(tree)
 
 
+def test_diagram_frame(snapshot):
+    """Nodes inside a Frame render as a Mermaid subgraph."""
+    with TreeBuilder("DiagramFrame") as tree:
+        geo_in = tree.inputs.geometry()
+        geo_out = tree.outputs.geometry()
+        with g.Frame("Transform"):
+            set_pos = g.SetPosition()
+            transform = g.TransformGeometry()
+        geo_in >> set_pos >> transform >> geo_out
+
+    assert snapshot == to_mermaid(tree)
+
+
+def test_diagram_nested_frames(snapshot):
+    """Frames nested inside frames produce nested subgraphs."""
+    with TreeBuilder("DiagramNestedFrame") as tree:
+        geo_in = tree.inputs.geometry()
+        geo_out = tree.outputs.geometry()
+        with g.Frame("Outer"):
+            set_pos = g.SetPosition()
+            with g.Frame("Inner"):
+                transform = g.TransformGeometry()
+        geo_in >> set_pos >> transform >> geo_out
+
+    assert snapshot == to_mermaid(tree)
+
+
 def test_diagram_bit_decoder(snapshot):
     N_BITS = 4
     with g.tree("8-Bit Decoder", arrange="simple") as tree:


### PR DESCRIPTION
When generating mermaid diagrams, we now properly take into account nodes belonging to frames.

