### PR TITLE
Remove `.type` from `BaseNode`

### DIFF
--- a/src/nodebpy/builder/_utils.py
+++ b/src/nodebpy/builder/_utils.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import bpy
 from bpy.types import NodeSocket
+
+if TYPE_CHECKING:
+    from ..types import SOCKET_TYPES
 
 
 class SocketError(Exception):
@@ -62,7 +65,7 @@ def _resolve_promotion(
 
     Returns (dominant_socket, effective_other, effective_reverse).
     """
-    other_type = getattr(other, "type", None)
+    other_type = _output_socket_type(other)
     self_prec = _TYPE_PRECEDENCE.get(self_socket.type, 1)
     other_prec = _TYPE_PRECEDENCE.get(other_type, -1) if other_type is not None else -1
 
@@ -89,3 +92,17 @@ class _SocketLike(Protocol):
     """Protocol for objects that wrap a single Blender NodeSocket and expose ``.socket``."""
 
     socket: NodeSocket
+
+
+def _output_socket_type(value: Any) -> "SOCKET_TYPES | None":
+    """The Blender socket ``type`` of *value*'s default output socket.
+
+    Resolves a raw ``NodeSocket`` or any socket/node wrapper to the type string
+    Blender uses (e.g. ``"VECTOR"``, ``"VALUE"``). Returns ``None`` for plain
+    Python values (ints, floats, tuples) that carry no socket type.
+    """
+    if isinstance(value, NodeSocket):
+        return value.type  # type: ignore[return-value]
+    if isinstance(value, (_SocketLike, _NodeLike)):
+        return value._default_output_socket.type  # type: ignore[return-value]
+    return None

--- a/src/nodebpy/builder/node.py
+++ b/src/nodebpy/builder/node.py
@@ -26,7 +26,7 @@ from bpy.types import (
     ShaderNodeTree,
 )
 
-from ..types import SOCKET_COMPATIBILITY, SOCKET_TYPES, InputAny
+from ..types import SOCKET_COMPATIBILITY, InputAny
 from ._utils import SocketError, _NodeLike, _SocketLike
 from .accessor import SocketAccessor
 from .mixins import LinkingMixin, OperatorMixin
@@ -91,14 +91,12 @@ class BaseNode(_NodeLike, OperatorMixin, LinkingMixin):
 
     @property
     def tree(self) -> TreeBuilder:
+        """The `TreeBuilder` instance this node belongs to and is being built within."""
         return self._tree
 
     @property
-    def type(self) -> SOCKET_TYPES:
-        return self._default_output_socket.type  # type: ignore
-
-    @property
     def name(self) -> str:
+        """The name of the node being wrapped by this instance."""
         return str(self.node.name)
 
     @property

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -83,7 +83,7 @@ from ..types import (
     InputVector,
 )
 from ._registry import _SOCKET_GRID_REGISTRY, _SOCKET_LIST_REGISTRY, _SOCKET_REGISTRY
-from ._utils import _NodeLike, _SocketLike
+from ._utils import _NodeLike, _output_socket_type, _SocketLike
 from .mixins import LinkingMixin, OperatorMixin
 
 if TYPE_CHECKING:
@@ -735,12 +735,11 @@ def _dispatch_vector_math(
     if operation == "multiply":
         if isinstance(other, (int, float)):
             return VectorMath.scale(socket, other).o.vector
-        if isinstance(other, NodeSocket) and other.type in ("VALUE", "FLOAT", "INT"):
-            return VectorMath.scale(socket, other).o.vector
-        if isinstance(other, (_SocketLike, _NodeLike)) and getattr(
-            other, "type", None
-        ) in ("VALUE", "FLOAT", "INT"):
-            return VectorMath.scale(socket, other._default_output_socket).o.vector
+        if _output_socket_type(other) in ("VALUE", "FLOAT", "INT"):
+            scale_by = (
+                other if isinstance(other, NodeSocket) else other._default_output_socket
+            )
+            return VectorMath.scale(socket, scale_by).o.vector
         if isinstance(other, (list, tuple)) and len(other) == 3:
             return VectorMath.multiply(*values).o.vector
         if isinstance(other, (_SocketLike, _NodeLike, NodeSocket)):
@@ -1763,7 +1762,7 @@ class _MatrixMixin(
         other = self._cast_to_matrix(other)
         socket = self._default_output_socket
 
-        if socket.type == "MATRIX" and other.type == "VECTOR":
+        if socket.type == "MATRIX" and _output_socket_type(other) == "VECTOR":
             return TransformPoint(other, socket).o.vector  # ty: ignore[invalid-return-type]
 
         return MultiplyMatrices(socket, other).o.matrix  # ty: ignore[invalid-return-type]
@@ -1774,7 +1773,7 @@ class _MatrixMixin(
         other = self._cast_to_matrix(other)
         socket = self._default_output_socket
 
-        if socket.type == "VECTOR" and getattr(other, "type", None) == "MATRIX":
+        if socket.type == "VECTOR" and _output_socket_type(other) == "MATRIX":
             return TransformPoint(socket, other).o.vector  # ty: ignore[invalid-return-type]
 
         return MultiplyMatrices(other, socket).o.matrix  # ty: ignore[invalid-return-type]


### PR DESCRIPTION
This is a socket-level property that was exposed on the `BaseNode` which didn't make sense for the API.