### PR TITLE
`enable_output()` socket method

### DIFF
--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -280,6 +280,34 @@ class Socket(BaseSocket, _SocketLike, OperatorMixin, LinkingMixin):
     # Called by OperatorMixin operators via _wrap_socket().
     # Subclasses (and type-specific mixins) override to provide type-specific behaviour.
 
+    def enable_output(self, enable: InputBoolean = True) -> "Self":
+        """Enable or disable the the output of this node group that is connected to this socket.
+
+        If called on an output socket, the output of the EnableOutput node is returned. If called on an input socket, the input socket is returned.
+
+        Parameters
+        ----------
+        enable : InputBoolean, optional
+            Whether to enable or disable the output, by default True.
+
+        Returns
+        -------
+        Self
+            The output socket or input socket, depending on the socket type.
+        """
+        from ..nodes.geometry import EnableOutput
+
+        if self.socket.is_output:
+            return EnableOutput(
+                enable,
+                self.socket,
+                data_type=self._socket_dtype,  # ty: ignore[invalid-argument-type]
+            ).o.value  # ty: ignore[invalid-return-type]
+        else:
+            enable = EnableOutput(enable, None, data_type=self._socket_dtype)  # ty: ignore[invalid-argument-type]
+            enable >> self.socket
+            return enable.i.value  # ty: ignore[invalid-return-type]
+
     def _dispatch_math(
         self, other: Any, operation: str, reverse: bool = False
     ) -> "FloatSocket":

--- a/tests/__snapshots__/test_interface.ambr
+++ b/tests/__snapshots__/test_interface.ambr
@@ -1,4 +1,23 @@
 # serializer version: 1
+# name: test_enable_output
+  '''
+  ```{mermaid}
+  graph LR
+      N0("Group Input"):::default-node
+      N1("Cube"):::geometry-node
+      N2("Ico Sphere"):::geometry-node
+      N3("Enable Output"):::default-node
+      N4("Enable Output"):::default-node
+      N5("Group Output"):::default-node
+      N0 -->|"Boolean->Enable"| N3
+      N1 -->|"Mesh->Value"| N3
+      N3 -->|"Value->Cube"| N5
+      N0 -->|"Boolean->Enable"| N4
+      N4 -->|"Value->IcoSphere"| N5
+      N2 -->|"Mesh->Value"| N4
+  ```
+  '''
+# ---
 # name: test_float_socket_methods
   '''
   ```{mermaid}

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1614,3 +1614,11 @@ def test_list_operations():
         length = lst.__len__()
         assert isinstance(length, IntegerSocket)
         assert length.node.bl_idname == g.ListLength._bl_idname
+
+def test_enable_output(snapshot):
+    with g.tree() as tree:
+        sel = tree.inputs.boolean()
+        g.Cube().o.mesh.enable_output(sel) >> tree.outputs.geometry("Cube")
+        g.IcoSphere() >> tree.outputs.geometry("IcoSphere").enable_output(sel)
+
+    assert snapshot == tree._repr_markdown_()


### PR DESCRIPTION
Adds the socket method `enable_output()` which can be used on all sockets to enable their visibility as outputs in the final node group.
