### PR TITLE
Fix: Linking and additional socket methods

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,6 +2,14 @@
 title: Changelog
 ---
 
+## v520.2.1 - UNRELEASED
+
+### Enhancements
+- Additional socket methods on `FloatSocket` and `IntegerSocket`.
+
+### Fixes
+- `FloatGridSocket.to_mesh()` method didn't link any of the input arguments, this now properly links and is tested against
+
 ## v520.2.0 - 2026-06-16
 
 ### Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nodebpy"
-version = "520.2.0"
+version = "520.2.1"
 description = "Build nodes trees in Blender more elegantly with code"
 readme = "README.md"
 authors = [

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -472,7 +472,9 @@ class _FloatGridOperatorMixin(Socket):
         """Generate a mesh on the "surface" of a volume grid."""
         from ..nodes.geometry import GridToMesh
 
-        return GridToMesh(self.socket).o.mesh
+        return GridToMesh(
+            self.socket, threshold=threshold, adaptivity=adaptivity
+        ).o.mesh
 
 
 class _VectorGridOperatorMixin(Socket):
@@ -1504,15 +1506,90 @@ class _FloatMixin(BaseSocket, Generic[_IntegerResult]):
 
         return Clamp.min_max(self.socket, min, max).o.result  # ty: ignore[invalid-return-type]
 
+    def min(self, value: InputFloat = 0.0) -> Self:
+        """Create Math with operation 'Minimum'. The minimum from self and value"""
+        self._assert_output("min")
+        return self._math.minimum(self.socket, value).o.value  # ty: ignore[invalid-return-type]
+
+    def max(self, value: InputFloat = 1.0) -> Self:
+        """Create Math with operation 'Maximum'. The maximum from self and value"""
+        self._assert_output("max")
+        return self._math.maximum(self.socket, value).o.value  # ty: ignore[invalid-return-type]
+
+    def sin(self) -> Self:
+        "Create a Math node with operation 'Sine'. The sine of self"
+        self._assert_output("sin")
+        return self._math.sine(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def cos(self) -> Self:
+        "Create a Math node with operation 'Cosine'. The cosine of self"
+        self._assert_output("cos")
+        return self._math.cosine(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def tan(self) -> Self:
+        "Create a Math node with operation 'Tangent'. The tangent of self"
+        self._assert_output("tan")
+        return self._math.tangent(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def asin(self) -> Self:
+        "Create a Math node with operation 'ArcSine'. The arcsine of self"
+        self._assert_output("asin")
+        return self._math.arcsine(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def acos(self) -> Self:
+        "Create a Math node with operation 'ArcCosine'. The arccosine of self"
+        self._assert_output("acos")
+        return self._math.arccosine(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def atan(self) -> Self:
+        "Create a Math node with operation 'ArcTangent'. The arctangent of self"
+        self._assert_output("atan")
+        return self._math.arctangent(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def sinh(self) -> Self:
+        "Create a Math node with operation 'Hyperbolic Sine'. The hyperbolic sine of self"
+        self._assert_output("sinh")
+        return self._math.hyperbolic_sine(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def cosh(self) -> Self:
+        "Create a Math node with operation 'Hyperbolic Cosine'. The hyperbolic cosine of self"
+        self._assert_output("cosh")
+        return self._math.hyperbolic_cosine(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def tanh(self) -> Self:
+        "Create a Math node with operation 'Hyperbolic Tangent'. The hyperbolic tangent of self"
+        self._assert_output("tanh")
+        return self._math.hyperbolic_tangent(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def exp(self) -> Self:
+        "Create a Math node with operation 'Exponent'. The exponent of self"
+        self._assert_output("exp")
+        return self._math.exponent(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def snap(self, increment: InputFloat = 0.5) -> Self:
+        "Create a Math node with operation 'Snap'. The snap of self"
+        self._assert_output("snap")
+        return self._math.snap(self.socket, increment).o.value  # ty: ignore[invalid-return-type]
+
+    def atan2(self, value: InputFloat = 0.5) -> Self:
+        "Create a Math node with operation 'ArcTan2'. The arctangent of self"
+        self._assert_output("atan2")
+        return self._math.arctan2(self.socket, value).o.value  # ty: ignore[invalid-return-type]
+
     def sqrt(self) -> Self:
         """Return the square root of this value."""
         self._assert_output("sqrt")
         return self._math.square_root(self.socket).o.value  # ty: ignore[invalid-return-type]
 
-    def power(self, exponent: InputFloat) -> Self:
+    def power(self, exponent: InputFloat = 2.0) -> Self:
         """Raise this value to *exponent*."""
         self._assert_output("power")
         return self._math.power(self.socket, exponent).o.value  # ty: ignore[invalid-return-type]
+
+    def log(self, base: InputFloat = 2.0) -> Self:
+        """Return the logarithm of this value to *base*."""
+        self._assert_output("log")
+        return self._math.logarithm(self.socket, base).o.value  # ty: ignore[invalid-return-type]
 
     def floor(self) -> Self:
         """Round down to the nearest integer."""
@@ -1524,15 +1601,35 @@ class _FloatMixin(BaseSocket, Generic[_IntegerResult]):
         self._assert_output("ceil")
         return self._math.ceil(self.socket).o.value  # ty: ignore[invalid-return-type]
 
+    def truncate(self) -> Self:
+        """The integer part of of the value, removing fractional digits"""
+        self._assert_output("truncate")
+        return self._math.truncate(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def fraction(self) -> Self:
+        """The fractional part of the vlaue"""
+        self._assert_output("fraction")
+        return self._math.fraction(self.socket).o.value  # ty: ignore[invalid-return-type]
+
     def round(self) -> Self:
         """Round to the nearest integer."""
         self._assert_output("round")
         return self._math.round(self.socket).o.value  # ty: ignore[invalid-return-type]
 
+    def ping_pong(self, value: InputFloat = 1.0) -> Self:
+        """Wrap around the range [0, value] using a ping-pong pattern."""
+        self._assert_output("ping_pong")
+        return self._math.ping_pong(self.socket, value).o.value  # ty: ignore[invalid-return-type]
+
     def modulo(self, divisor: InputFloat) -> Self:
         """Floored modulo — remainder after dividing by *divisor*, always non-negative."""
         self._assert_output("modulo")
         return self._math.floored_modulo(self.socket, divisor).o.value  # ty: ignore[invalid-return-type]
+
+    def abs(self) -> Self:
+        """Absolute value of the input"""
+        self._assert_output("abs")
+        return self._math.absolute(self.socket).o.value  # ty: ignore[invalid-return-type]
 
     def wrap(self, min: InputFloat, max: InputFloat) -> Self:
         """Wrap the value into the *[min, max]* range, repeating cyclically."""
@@ -1540,6 +1637,11 @@ class _FloatMixin(BaseSocket, Generic[_IntegerResult]):
         # the wrap method has different order of arguments with max being first
         # compared to other nodes that are defined.
         return self._math.wrap(self.socket, value_001=max, value_002=min).o.value  # ty: ignore[invalid-return-type]
+
+    def mul_add(self, multiplier: InputFloat = 0.5, addend: InputFloat = 0.5) -> Self:
+        "Multiply and then add a value. More efficient as it is a single CPU instruction."
+        self._assert_output("mul_add")
+        return self._math.multiply_add(self.socket, multiplier, addend).o.value  # ty: ignore[invalid-return-type]
 
     def to_radians(self) -> Self:
         """Convert degrees to radians."""
@@ -1601,6 +1703,16 @@ class _IntegerMixin(BaseSocket, Generic[_FloatResult]):
         """Negate the IntegerSocket value. Positive becomes negative, negative becomes positive."""
         self._assert_output("negate")
         return self._imath.negate(self.socket).o.value  # ty: ignore[invalid-return-type]
+
+    def mul_add(self, multiplier: InputInteger = 0, addend: InputInteger = 0) -> Self:
+        "Multiply and then add a value. More efficient as it is a single CPU instruction."
+        self._assert_output("mul_add")
+        return self._imath.multiply_add(self.socket, multiplier, addend).o.value  # ty: ignore[invalid-return-type]
+
+    def power(self, exponent: InputInteger = 2) -> Self:
+        """Raise this value to *exponent*."""
+        self._assert_output("power")
+        return self._imath.power(self.socket, exponent).o.value  # ty: ignore[invalid-return-type]
 
     @staticmethod
     def _is_integer_socket(value: Any) -> bool:

--- a/tests/__snapshots__/test_interface.ambr
+++ b/tests/__snapshots__/test_interface.ambr
@@ -23,53 +23,61 @@
   ```{mermaid}
   graph LR
       N0("Value"):::input-node
-      N1("Value to String"):::converter-node
+      N1("Math<br/><small>(SNAP)</small>"):::converter-node
       N2("Math<br/><small>(EXPONENT)</small>"):::converter-node
       N3("Math<br/><small>(ARCSINE)</small>"):::converter-node
       N4("Math<br/><small>(POWER)</small>"):::converter-node
       N5("Math<br/><small>(RADIANS)</small>"):::converter-node
-      N6("Value"):::input-node
-      N7("Math<br/><small>(ARCTANGENT)</small>"):::converter-node
-      N8("Math<br/><small>(DEGREES)</small>"):::converter-node
-      N9("Math<br/><small>(MINIMUM)</small>"):::converter-node
-      N10("Math<br/><small>(MULTIPLY)</small>"):::converter-node
+      N6("Math<br/><small>(ARCTANGENT)</small>"):::converter-node
+      N7("Math<br/><small>(DEGREES)</small>"):::converter-node
+      N8("Math<br/><small>(MINIMUM)</small>"):::converter-node
+      N9("Math<br/><small>(MULTIPLY)</small>"):::converter-node
+      N10("Math<br/><small>(TRUNC)</small>"):::converter-node
       N11("Math<br/><small>(SQRT)</small>"):::converter-node
       N12("Math<br/><small>(COSH)</small>"):::converter-node
       N13("Math<br/><small>(SIGN)</small>"):::converter-node
       N14("Math<br/><small>(MULTIPLY_ADD)</small>"):::converter-node
-      N15("Math<br/><small>(COSINE)</small>"):::converter-node
-      N16("Math<br/><small>(MAXIMUM)</small>"):::converter-node
-      N17("Math<br/><small>(LOGARITHM)</small>"):::converter-node
-      N18("Math<br/><small>(TANH)</small>"):::converter-node
-      N19("Math<br/><small>(TANGENT)</small>"):::converter-node
-      N20("Math<br/><small>(SINE)</small>"):::converter-node
-      N21("Math<br/><small>(PINGPONG)</small>"):::converter-node
-      N22("Math<br/><small>(ARCTAN2)</small>"):::converter-node
-      N23("Math<br/><small>(SINH)</small>"):::converter-node
-      N24("Math<br/><small>(ARCCOSINE)</small>"):::converter-node
-      N0 -->|"Value->Value"| N10
-      N0 -->|"Value->Value"| N1
-      N0 -->|"Value->Value"| N13
+      N15("Value to String"):::converter-node
+      N16("Math<br/><small>(COSINE)</small>"):::converter-node
+      N17("Math<br/><small>(MAXIMUM)</small>"):::converter-node
+      N18("Math<br/><small>(LOGARITHM)</small>"):::converter-node
+      N19("Math<br/><small>(ABSOLUTE)</small>"):::converter-node
+      N20("Math<br/><small>(TANH)</small>"):::converter-node
+      N21("Math<br/><small>(TANGENT)</small>"):::converter-node
+      N22("Math<br/><small>(SINE)</small>"):::converter-node
+      N23("Math<br/><small>(PINGPONG)</small>"):::converter-node
+      N24("Math<br/><small>(ARCTAN2)</small>"):::converter-node
+      N25("Math<br/><small>(SINH)</small>"):::converter-node
+      N26("Math<br/><small>(FRACT)</small>"):::converter-node
+      N27("Math<br/><small>(ARCCOSINE)</small>"):::converter-node
+      N28("Value"):::input-node
       N0 -->|"Value->Value"| N9
-      N0 -->|"Value->Value"| N16
-      N0 -->|"Value->Value"| N20
       N0 -->|"Value->Value"| N15
-      N0 -->|"Value->Value"| N19
-      N0 -->|"Value->Value"| N3
-      N0 -->|"Value->Value"| N24
-      N0 -->|"Value->Value"| N7
-      N0 -->|"Value->Value"| N23
-      N0 -->|"Value->Value"| N12
-      N0 -->|"Value->Value"| N18
+      N0 -->|"Value->Value"| N13
+      N0 -->|"Value->Value"| N8
+      N0 -->|"Value->Value"| N17
       N0 -->|"Value->Value"| N22
+      N0 -->|"Value->Value"| N16
+      N0 -->|"Value->Value"| N21
+      N0 -->|"Value->Value"| N3
+      N0 -->|"Value->Value"| N27
+      N0 -->|"Value->Value"| N6
+      N0 -->|"Value->Value"| N25
+      N0 -->|"Value->Value"| N12
+      N0 -->|"Value->Value"| N20
+      N0 -->|"Value->Value"| N24
       N0 -->|"Value->Value"| N11
       N0 -->|"Value->Value"| N4
-      N0 -->|"Value->Value"| N17
+      N0 -->|"Value->Value"| N18
       N0 -->|"Value->Value"| N2
-      N0 -->|"Value->Value"| N8
+      N0 -->|"Value->Value"| N7
       N0 -->|"Value->Value"| N5
       N0 -->|"Value->Value"| N14
-      N0 -->|"Value->Value"| N21
+      N0 -->|"Value->Value"| N23
+      N0 -->|"Value->Value"| N1
+      N0 -->|"Value->Value"| N10
+      N0 -->|"Value->Value"| N26
+      N0 -->|"Value->Value"| N19
   ```
   '''
 # ---

--- a/tests/__snapshots__/test_interface.ambr
+++ b/tests/__snapshots__/test_interface.ambr
@@ -23,12 +23,53 @@
   ```{mermaid}
   graph LR
       N0("Value"):::input-node
-      N1("Math<br/><small>(SIGN)</small>"):::converter-node
-      N2("Math<br/><small>(MULTIPLY)</small>"):::converter-node
-      N3("Value to String"):::converter-node
+      N1("Value to String"):::converter-node
+      N2("Math<br/><small>(EXPONENT)</small>"):::converter-node
+      N3("Math<br/><small>(ARCSINE)</small>"):::converter-node
+      N4("Math<br/><small>(POWER)</small>"):::converter-node
+      N5("Math<br/><small>(RADIANS)</small>"):::converter-node
+      N6("Value"):::input-node
+      N7("Math<br/><small>(ARCTANGENT)</small>"):::converter-node
+      N8("Math<br/><small>(DEGREES)</small>"):::converter-node
+      N9("Math<br/><small>(MINIMUM)</small>"):::converter-node
+      N10("Math<br/><small>(MULTIPLY)</small>"):::converter-node
+      N11("Math<br/><small>(SQRT)</small>"):::converter-node
+      N12("Math<br/><small>(COSH)</small>"):::converter-node
+      N13("Math<br/><small>(SIGN)</small>"):::converter-node
+      N14("Math<br/><small>(MULTIPLY_ADD)</small>"):::converter-node
+      N15("Math<br/><small>(COSINE)</small>"):::converter-node
+      N16("Math<br/><small>(MAXIMUM)</small>"):::converter-node
+      N17("Math<br/><small>(LOGARITHM)</small>"):::converter-node
+      N18("Math<br/><small>(TANH)</small>"):::converter-node
+      N19("Math<br/><small>(TANGENT)</small>"):::converter-node
+      N20("Math<br/><small>(SINE)</small>"):::converter-node
+      N21("Math<br/><small>(PINGPONG)</small>"):::converter-node
+      N22("Math<br/><small>(ARCTAN2)</small>"):::converter-node
+      N23("Math<br/><small>(SINH)</small>"):::converter-node
+      N24("Math<br/><small>(ARCCOSINE)</small>"):::converter-node
+      N0 -->|"Value->Value"| N10
       N0 -->|"Value->Value"| N1
-      N0 -->|"Value->Value"| N2
+      N0 -->|"Value->Value"| N13
+      N0 -->|"Value->Value"| N9
+      N0 -->|"Value->Value"| N16
+      N0 -->|"Value->Value"| N20
+      N0 -->|"Value->Value"| N15
+      N0 -->|"Value->Value"| N19
       N0 -->|"Value->Value"| N3
+      N0 -->|"Value->Value"| N24
+      N0 -->|"Value->Value"| N7
+      N0 -->|"Value->Value"| N23
+      N0 -->|"Value->Value"| N12
+      N0 -->|"Value->Value"| N18
+      N0 -->|"Value->Value"| N22
+      N0 -->|"Value->Value"| N11
+      N0 -->|"Value->Value"| N4
+      N0 -->|"Value->Value"| N17
+      N0 -->|"Value->Value"| N2
+      N0 -->|"Value->Value"| N8
+      N0 -->|"Value->Value"| N5
+      N0 -->|"Value->Value"| N14
+      N0 -->|"Value->Value"| N21
   ```
   '''
 # ---

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -875,6 +875,12 @@ def test_boolean_socket_switches():
             assert sock.node.input_type == name
 
 
+def _assert_integer_method(result, operation):
+    node = cast(g.IntegerMath, result.builder_node)
+    assert isinstance(node, g.IntegerMath)
+    assert node.operation == operation
+
+
 def test_integer_socket_methods():
     with g.tree():
         val = g.Integer().o.integer
@@ -897,26 +903,66 @@ def test_integer_socket_methods():
         assert isinstance(node, g.ValueToString)
         assert node.data_type == "INT"
 
+        for method, operation in [
+            ("sign", "SIGN"),
+            ("negate", "NEGATE"),
+            ("abs", "ABSOLUTE"),
+            ("mul_add", "MULTIPLY_ADD"),
+            ("power", "POWER"),
+        ]:
+            result = getattr(val, method)()
+            _assert_integer_method(result, operation)
+
+
+def _assert_method(result, expected_operation):
+    assert result.node.bl_idname == g.Math._bl_idname
+    assert result.node.operation == expected_operation
+
 
 def test_float_socket_methods(snapshot):
     with g.tree() as tree:
         val = g.Float().o.value
-
-        result = val.sign()
-        assert result.node.bl_idname == g.Math._bl_idname
-        assert result.node.operation == "SIGN"
+        b = g.Float().o.value
 
         result = val.negate()
-        assert result.node.bl_idname == g.Math._bl_idname
-        assert result.node.operation == "MULTIPLY"
+        _assert_method(result, "MULTIPLY")
         assert result.node.inputs[1].default_value == pytest.approx(-1.0)
         assert result.node.inputs[0].links[0].from_node == val.node
-        assert len(val.links) == 2
+        assert len(val.links) == 1
 
         string = val.to_string(3)
         assert string.builder_node.i.decimals.default_value == 3
         assert isinstance(string.builder_node, g.ValueToString)
-        assert snapshot == tree._repr_markdown_()
+
+        for method, operation in [
+            ("sign", "SIGN"),
+            ("min", "MINIMUM"),
+            ("max", "MAXIMUM"),
+            ("sin", "SINE"),
+            ("cos", "COSINE"),
+            ("tan", "TANGENT"),
+            ("asin", "ARCSINE"),
+            ("acos", "ARCCOSINE"),
+            ("atan", "ARCTANGENT"),
+            ("sinh", "SINH"),
+            ("cosh", "COSH"),
+            ("tanh", "TANH"),
+            ("atan2", "ARCTAN2"),
+            # ("asinh", "ARCSINH"),
+            # ("acosh", "ARCCOSH"),
+            # ("atanh", "ARCTANH"),
+            ("sqrt", "SQRT"),
+            ("power", "POWER"),
+            ("log", "LOGARITHM"),
+            ("exp", "EXPONENT"),
+            ("to_degrees", "DEGREES"),
+            ("to_radians", "RADIANS"),
+            ("mul_add", "MULTIPLY_ADD"),
+            ("ping_pong", "PINGPONG"),
+        ]:
+            _assert_method(getattr(val, method)(), operation)
+
+    assert snapshot == tree.to_mermaid()
 
 
 def test_vector_socket_methods(snapshot):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -959,6 +959,10 @@ def test_float_socket_methods(snapshot):
             ("to_radians", "RADIANS"),
             ("mul_add", "MULTIPLY_ADD"),
             ("ping_pong", "PINGPONG"),
+            ("snap", "SNAP"),
+            ("truncate", "TRUNC"),
+            ("fraction", "FRACT"),
+            ("abs", "ABSOLUTE"),
         ]:
             _assert_method(getattr(val, method)(), operation)
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1993,7 +1993,15 @@ def test_grid_socket_methods():
         assert isinstance(fgrid.sdf_mean_curvature(), FloatSocketGrid)
         assert isinstance(fgrid.sdf_median(), FloatSocketGrid)
         assert isinstance(fgrid.sdf_offset(), FloatSocketGrid)
-        assert isinstance(fgrid.to_mesh(), GeometrySocket)
+
+        to_mesh = fgrid.to_mesh(threshold=g.Value(2.0), adaptivity=g.Value(0.0))
+        assert isinstance(to_mesh, GeometrySocket)
+        node = to_mesh.builder_node
+        assert isinstance(node, g.GridToMesh)
+        assert node.i.adaptivity.links
+        assert node.i.threshold.links
+        assert node.i.adaptivity.links[0].from_node.bl_idname == g.Value._bl_idname
+        assert node.i.threshold.links[0].from_node.bl_idname == g.Value._bl_idname
 
         # _VectorGridOperatorMixin (vector grids only)
         assert isinstance(vgrid.curl(), VectorSocketGrid)

--- a/uv.lock
+++ b/uv.lock
@@ -206,9 +206,9 @@ dependencies = [
     { name = "zstandard" },
 ]
 wheels = [
-    { url = "https://github.com/BradyAJohnston/dailybpy/releases/download/daily-2026-06-16/bpy-5.2.0b0-cp313-cp313-macosx_11_0_arm64.whl" },
-    { url = "https://github.com/BradyAJohnston/dailybpy/releases/download/daily-2026-06-16/bpy-5.2.0b0-cp313-cp313-manylinux_2_39_x86_64.whl" },
-    { url = "https://github.com/BradyAJohnston/dailybpy/releases/download/daily-2026-06-16/bpy-5.2.0b0-cp313-cp313-win_amd64.whl" },
+    { url = "https://github.com/BradyAJohnston/dailybpy/releases/download/daily-2026-06-17/bpy-5.2.0b0-cp313-cp313-macosx_11_0_arm64.whl" },
+    { url = "https://github.com/BradyAJohnston/dailybpy/releases/download/daily-2026-06-17/bpy-5.2.0b0-cp313-cp313-manylinux_2_39_x86_64.whl" },
+    { url = "https://github.com/BradyAJohnston/dailybpy/releases/download/daily-2026-06-17/bpy-5.2.0b0-cp313-cp313-win_amd64.whl" },
 ]
 
 [[package]]
@@ -226,11 +226,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "nodebpy"
-version = "520.2.0"
+version = "520.2.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
The `FloatGridSocket.to_mesh()` method didn't link any of the input arguments. This is now fixed & tested against.

Additional socket methods are added on `FloatSocket` and `IntegerSocket` which are the math node methods.

- **more socket methods and tests**
- **tests for fixed  method**
