### PR TITLE
Preserve Value node defaults in Python export

### DIFF
--- a/src/nodebpy/export/codegen.py
+++ b/src/nodebpy/export/codegen.py
@@ -3665,6 +3665,22 @@ def _emit_tree(node_tree, collector: "_GroupCollector") -> "_TreeEmission":
 # ---------------------------------------------------------------------------
 
 
+@register_emitter("ShaderNodeValue")
+def _emit_value(node, ctx: EmitContext) -> Call:
+    """Preserve the Value node's output-backed constructor argument.
+
+    Unlike ordinary node inputs, ``ShaderNodeValue`` stores its editable value
+    directly on its output socket. The generic constructor path only examines
+    input sockets, so a non-zero value needs to be supplied explicitly.
+    """
+    call = ctx.constructor(node)
+    if node.outputs:
+        value = node.outputs[0].default_value
+        if not _eq(value, 0.0):
+            call.args.append(Lit(value))
+    return call
+
+
 _COMPARE_LIFT = {
     "LESS_THAN": "<",
     "GREATER_THAN": ">",

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -178,6 +178,25 @@ def test_unlinked_non_default_input():
     assert "3.14" in code
 
 
+def test_value_output_default_round_trips():
+    """Value stores its constructor value on its output socket, not an input."""
+    with TreeBuilder("ValueOutputDefault") as tree:
+        out = tree.outputs.geometry("Geometry")
+        size = g.Value(0.05)
+        g.Grid(size_x=size, size_y=size, vertices_x=4, vertices_y=4) >> out
+
+    code = to_python(tree, format=False)
+    assert "g.Value(0.05)" in code
+
+    namespace: dict = {}
+    exec(code, namespace)  # noqa: S102
+    rebuilt: TreeBuilder = namespace["tree"]
+    value_node = next(
+        node for node in rebuilt.tree.nodes if node.bl_idname == "ShaderNodeValue"
+    )
+    assert value_node.outputs[0].default_value == pytest.approx(0.05)
+
+
 def test_fanout_assigns_variable():
     """Every node gets a named variable (Phase 1 rule)."""
     with TreeBuilder("FanOut") as tree:


### PR DESCRIPTION
## Summary

- preserve non-zero `Value` node defaults in generated Python
- add a regression test that executes the export and verifies the rebuilt value

## Why

`ShaderNodeValue` stores its editable value on its output socket. The generic exporter only inspected input sockets, so `g.Value(0.05)` was emitted as `g.Value()` and silently rebuilt as `0.0`.

The new built-in emitter passes the output-backed value to the constructor while retaining the concise `g.Value()` form for the zero default.

## Impact

Geometry node trees using a `Value` node now round-trip through `to_python()` without changing dimensions or other downstream calculations.

## Validation

- reproduced and verified the round-trip in Blender 5.2
- `tests/test_codegen.py`: 246 passed, 1 skipped
- Ruff lint and formatting checks passed
- `git diff --check` passed
