### PR TITLE
Split asset writing by tree type

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -97,6 +97,7 @@ quartodoc:
       desc: Generating classes from pre-build assets
       contents:
         - assets.generate_asset_api
+        - assets.generate_asset_modules
         - assets.AssetLibrary
         - assets.BundledLibrary
         - assets.PackageLibrary

--- a/docs/assets.qmd
+++ b/docs/assets.qmd
@@ -54,6 +54,24 @@ package (resolved relative to `anchor`, usually `__file__`); use
 of libraries to merge several into one module, and `names={...}` to restrict
 generation to specific node groups.
 
+If your libraries mix tree types, use `generate_asset_modules` instead — it
+takes a directory and writes one module per tree type (`geometry.py`,
+`shader.py`, `compositor.py`), skipping tree types with no assets:
+
+```{python}
+# | eval: false
+from nodebpy.assets import generate_asset_modules, PackageLibrary
+
+generate_asset_modules(
+    PackageLibrary(__file__, "data/my_assets.blend"),
+    "my_addon/nodes/",
+)
+```
+
+Because asset names repeat across editors, splitting also keeps the generated
+class names collision-free where a single mixed module would silently shadow
+one tree type's class with another's.
+
 The generated module imports from `nodebpy` and looks like any other node
 module, so import and use it directly:
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,7 +2,38 @@
 title: Changelog
 ---
 
-## v520.5.0 - 2026-06-16
+## v520.7.0 - 2026-07-16
+
+### Enhancements
+- **Per-tree-type asset modules** — `nodebpy.assets.generate_asset_modules(libraries, output_dir)` splits the generated asset classes into one module per tree type (`geometry.py` / `shader.py` / `compositor.py`), writing only the tree types that have assets. Asset names repeat across editors (a geometry *and* a compositor "Combine Spherical" both exist), so splitting keeps the generated class names collision-free where a single `generate_asset_api` module would silently shadow one with the other. The CLI splits the same way when the output is a directory:
+
+```sh
+python -m nodebpy.assets -b my_assets.blend -o my_addon/nodes/
+```
+
+## v520.6.0 - 2026-07-15
+
+### Enhancements
+- **Blender 5.2 stable** — `bpy` now tracks the final 5.2 release (CI no longer installs daily builds); the node classes and bundled-essentials asset APIs were regenerated against it. The `SetAttachmentSurface` asset was removed upstream and is no longer generated.
+
+### Fixes
+- `to_python` export now preserves a `Value` node's number. The editable value lives on the node's *output* socket, which the generic constructor path never examined, so non-default values were silently dropped from the generated code.
+
+## v520.5.2 - 2026-07-07
+
+### Internal
+- Documentation cleanup.
+
+## v520.5.1 - 2026-07-07
+
+### Enhancements
+- **Interactive graphs in docs / notebooks** — a `TreeBuilder` now displays as an interactive, Blender-styled, pan-and-zoomable node graph in Jupyter and Quarto (via `_repr_html_`, backed by the new `nodebpy.web_render` module using `tree_clipper` and the `geonodes-web-render` web component). Falls back to the existing Mermaid diagram when rendering isn't available.
+
+### Fixes
+- `to_python` export: a single link into a multi-input socket is now emitted as a one-element tuple, since the manual classes (`JoinGeometry`, `MeshBoolean`, …) expect an iterable — previously such trees didn't round-trip. Unary float/integer math socket methods also emit Blender's zero-padded socket identifiers (`Value_001`).
+- Regenerated the bundled asset APIs with upstream label fixes — e.g. `cip_start` → `clip_start`, `animated_` → `animated`, and the "Super 8 mm" film-grain preset spelling.
+
+## v520.5.0 - 2026-06-19
 
 ### Enhancements
 - Changed the linking of asset node groups for the `_AssetGroupMixin` to be 'linked & packed' by default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nodebpy"
-version = "520.6.0"
+version = "520.7.0"
 description = "Build nodes trees in Blender more elegantly with code"
 readme = "README.md"
 authors = [

--- a/src/nodebpy/assets/__init__.py
+++ b/src/nodebpy/assets/__init__.py
@@ -1,16 +1,19 @@
 """Typed APIs for node-group assets.
 
 ``generate_asset_api`` builds typed :class:`~nodebpy.builder.AssetNodeGroup`
-classes for the node groups in a ``.blend`` asset library. The bundled-essentials
-APIs generated for nodebpy itself live alongside this module as
-``nodebpy.assets.geometry`` / ``.shader`` / ``.compositor``.
+classes for the node groups in a ``.blend`` asset library into a single module;
+``generate_asset_modules`` splits them into one module per tree type
+(``geometry.py`` / ``shader.py`` / ``compositor.py``). The bundled-essentials
+APIs generated for nodebpy itself live in ``nodebpy.nodes.{geometry,shader,
+compositor}.assets`` and are re-exported alongside the built-in nodes.
 """
 
 from ..builder import AssetLibrary, BundledLibrary, PackageLibrary
-from ._codegen import generate_asset_api
+from ._codegen import generate_asset_api, generate_asset_modules
 
 __all__ = [
     "generate_asset_api",
+    "generate_asset_modules",
     "AssetLibrary",
     "BundledLibrary",
     "PackageLibrary",

--- a/src/nodebpy/assets/__main__.py
+++ b/src/nodebpy/assets/__main__.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 
 from ..builder import BundledLibrary, PackageLibrary
-from ._codegen import generate_asset_api
+from ._codegen import generate_asset_api, generate_asset_modules
 
 # Bundled libraries shipped with Blender, grouped by output module. Each library
 # holds node groups of a single tree type.
@@ -70,7 +70,11 @@ def parse_args() -> argparse.Namespace:
         "-o",
         dest="output",
         type=Path,
-        help="Path of the assets.py module to write.",
+        help=(
+            "Where to write the generated module(s). A .py path writes a single "
+            "module; a directory writes one module per tree type "
+            "(geometry.py / shader.py / compositor.py)."
+        ),
     )
     parser.add_argument(
         "--nodebpy-pkg",
@@ -98,6 +102,16 @@ def main() -> None:  # pragma: no cover - CLI wrapper
         # directory (``__file__``), so express the .blend relative to the output
         # module — not the CWD the command happened to run from.
         blend = args.blend_file.resolve()
+        if output.suffix != ".py":
+            # Directory output: one module per tree type.
+            out_dir = output.resolve()
+            relative = Path(os.path.relpath(blend, out_dir)).as_posix()
+            generate_asset_modules(
+                [PackageLibrary(str(out_dir / "_anchor.py"), relative)],
+                output,
+                nodebpy_pkg=args.nodebpy_pkg,
+            )
+            return
         relative = Path(os.path.relpath(blend, output.resolve().parent)).as_posix()
         generate_asset_api(
             [PackageLibrary(str(output), relative)],

--- a/src/nodebpy/assets/_codegen.py
+++ b/src/nodebpy/assets/_codegen.py
@@ -50,6 +50,14 @@ _SOCKET_TYPES: dict[str, tuple[str, str]] = {
 }
 
 
+# Tree type → module name used when splitting generated output per tree type.
+_TREE_MODULES: dict[str, str] = {
+    "GeometryNodeTree": "geometry",
+    "ShaderNodeTree": "shader",
+    "CompositorNodeTree": "compositor",
+}
+
+
 def _socket_types(bl_socket_type: str) -> tuple[str, str]:
     for key, value in _SOCKET_TYPES.items():
         if key in bl_socket_type:
@@ -329,3 +337,47 @@ def generate_asset_api(
         _render_module(classes, nodebpy_pkg=nodebpy_pkg), encoding="utf-8"
     )
     return [c.class_name for c in classes]
+
+
+def generate_asset_modules(
+    libraries: AssetLibrary | Sequence[AssetLibrary],
+    output_dir: str | Path,
+    *,
+    names: set[str] | None = None,
+    nodebpy_pkg: str = "nodebpy",
+) -> dict[str, list[str]]:
+    """Generate typed asset classes for ``libraries``, split into one module per
+    tree type inside ``output_dir``.
+
+    Writes ``geometry.py``, ``shader.py`` and/or ``compositor.py`` — one module
+    for each tree type that has assets in the libraries (no file for the
+    others). Asset names repeat across editors (a geometry *and* a compositor
+    "Combine Spherical" both exist), so splitting keeps the generated class
+    names collision-free where a single :func:`generate_asset_api` module would
+    silently shadow one with the other.
+
+    Parameters are as for :func:`generate_asset_api`, except ``output_dir`` is
+    the directory to write the modules into (created if needed).
+
+    Returns a mapping of module name (``"geometry"`` / ``"shader"`` /
+    ``"compositor"``) to the class names written to it.
+    """
+    if isinstance(libraries, AssetLibrary):
+        libraries = [libraries]
+
+    classes: list[_AssetClass] = []
+    for library in libraries:
+        classes.extend(_introspect(library, names))
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: dict[str, list[str]] = {}
+    for tree_idname, module in _TREE_MODULES.items():
+        tree_classes = [c for c in classes if c.tree_idname == tree_idname]
+        if not tree_classes:
+            continue
+        (output_dir / f"{module}.py").write_text(
+            _render_module(tree_classes, nodebpy_pkg=nodebpy_pkg), encoding="utf-8"
+        )
+        written[module] = [c.class_name for c in tree_classes]
+    return written

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import pytest
 
 from nodebpy import TreeBuilder
-from nodebpy.assets import BundledLibrary, PackageLibrary, _codegen, generate_asset_api
+from nodebpy.assets import (
+    BundledLibrary,
+    PackageLibrary,
+    _codegen,
+    generate_asset_api,
+    generate_asset_modules,
+)
 from nodebpy.assets.__main__ import generate_essentials
 from nodebpy.builder import BaseNode, asset_group_base
 from nodebpy.nodes import compositor as nc
@@ -153,6 +159,25 @@ def test_generate_with_package_library(tmp_path):
     generate_asset_api(lib, out, names={"Smooth by Angle"})
     source = out.read_text()
     assert "PackageLibrary(__file__, " in source
+
+
+@_needs_essentials
+def test_generate_modules_split_by_tree(tmp_path):
+    """Mixed-tree-type libraries are split into one module per tree type, and
+    tree types with no assets get no file."""
+    libraries = [_ESSENTIALS]
+    shader = BundledLibrary("shading_nodes_essentials.blend")
+    if os.path.exists(shader.path()):
+        libraries.append(shader)
+    written = generate_asset_modules(libraries, tmp_path)
+    assert written["geometry"]
+    assert (tmp_path / "geometry.py").exists()
+    assert "__all__" in (tmp_path / "geometry.py").read_text()
+    if len(libraries) == 2:
+        assert written["shader"]
+        assert (tmp_path / "shader.py").exists()
+    assert "compositor" not in written
+    assert not (tmp_path / "compositor.py").exists()
 
 
 def test_library_source_renders_path_as_plain_string():

--- a/uv.lock
+++ b/uv.lock
@@ -1212,7 +1212,7 @@ wheels = [
 
 [[package]]
 name = "nodebpy"
-version = "520.6.0"
+version = "520.7.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Splits asset creation into compositor/geometry/shader.py depending on tree type. Also updates changelog for previous changes.
