### PR TITLE
Added group nodes are renamed

### DIFF
--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,1 +1,1 @@
-version: 520.7.0
+version: 520.8.0

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## v520.8.0 - 2026-07-17
+
+### Enhancements
+- **Group nodes are named after their tree** — adding a custom node group (`CustomGeometryGroup` / `CustomShaderGroup` / `CustomCompositorGroup`, including asset-backed groups) now names the group *node* after its node tree (e.g. `Smooth by Angle`, `Smooth by Angle.001`) instead of Blender's default `Group` / `Group.001`, matching how group assets are named when added from the Add menu.
+
 ## v520.7.0 - 2026-07-16
 
 ### Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nodebpy"
-version = "520.7.0"
+version = "520.8.0"
 description = "Build nodes trees in Blender more elegantly with code"
 readme = "README.md"
 authors = [

--- a/src/nodebpy/builder/node.py
+++ b/src/nodebpy/builder/node.py
@@ -387,6 +387,10 @@ class NodeGroupBuilder(BaseNode, ABC, Generic[_T]):
         self._establish_links(**kwargs)
         if named_links:
             self._establish_named_links(named_links)
+        # Name the node after its tree (Blender deduplicates with a
+        # ``.001``-style suffix), matching how group assets added from the
+        # Add menu are named, instead of Blender's default ``Group``.
+        self.node.name = self.node_tree.name
 
     @property
     @abstractmethod

--- a/tests/__snapshots__/test_codegen.ambr
+++ b/tests/__snapshots__/test_codegen.ambr
@@ -169,7 +169,7 @@
   # Restore authored node positions.
   tree.node_positions = {
       "Group Input": (0.0, 0.0),
-      "Group": (120.0, 50.0),
+      "SnapInner": (120.0, 50.0),
       "Group Output": (240.0, 100.0),
   }
   '''

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -70,6 +70,7 @@ def test_generated_asset_appends_and_links():
         node = ng.SmoothByAngle(mesh=ng.Cube(), angle=0.5)
         assert node.node.node_tree is not None
         assert node.node.node_tree.name == "Smooth by Angle"
+        assert node.node.name == "Smooth by Angle"
         assert node.o.mesh is not None
         assert any(socket.is_linked for socket in node.node.inputs)
 

--- a/tests/test_custom_groups.py
+++ b/tests/test_custom_groups.py
@@ -216,6 +216,35 @@ def test_group_reuses_existing_node_group():
     assert a.node is not b.node
 
 
+# --- Node naming ---
+
+
+def test_group_node_named_after_tree():
+    """The group node is named after its node tree, not Blender's default
+    'Group', matching how assets added from the Add menu are named."""
+    with TreeBuilder():
+        geom = _SimpleGeomGroup()
+    assert geom.node.name == "Test Simple Geometry Group"
+
+    with TreeBuilder.shader():
+        shader = _SimpleShaderGroup()
+    assert shader.node.name == "Test Simple Shader Group"
+
+    with TreeBuilder.compositor():
+        comp = _SimpleCompositorGroup()
+    assert comp.node.name == "Test Simple Compositor Group"
+
+
+def test_group_node_name_deduplicated():
+    """Repeated instances in one tree get Blender's .001-style suffixes."""
+    with TreeBuilder():
+        a = _SimpleGeomGroup()
+        b = _SimpleGeomGroup()
+
+    assert a.node.name == "Test Simple Geometry Group"
+    assert b.node.name == "Test Simple Geometry Group.001"
+
+
 # ---------------------------------------------------------------------------
 # ShaderNodeGroup
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1212,7 +1212,7 @@ wheels = [
 
 [[package]]
 name = "nodebpy"
-version = "520.7.0"
+version = "520.8.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Group nodes are renamed to have the name of the node tree, aligned with the GUI add experience.

