### PR TITLE
Codegen and gen/ module cleanup fixes

### DIFF
--- a/gen/emit.py
+++ b/gen/emit.py
@@ -34,6 +34,18 @@ def generate_node_class(node_info: NodeInfo, config: TreeTypeConfig) -> str:
     is_generic = outputs_generic or inputs_generic
     if not inputs_generic:
         varying_inputs = set()
+    # Mixed grid/non-grid generics (Set Grid Background: Grid is a
+    # FloatSocketGrid while Background is a FloatSocket) take a second
+    # TGrid/SGrid type parameter; grid-only generics bind their single
+    # parameter to the *SocketGrid classes directly. Mixed list/non-list
+    # generics (Get List Item: List is a FloatSocketList while Value is a
+    # FloatSocket) likewise take a second TList/SList parameter.
+    mixed_grid = is_generic and node_info.generic_mixed_grid
+    varying_grid_inputs = node_info.varying_grid_inputs if mixed_grid else set()
+    varying_grid_outputs = node_info.varying_grid_outputs if mixed_grid else set()
+    mixed_list = is_generic and node_info.generic_mixed_list
+    varying_list_inputs = node_info.varying_list_inputs if mixed_list else set()
+    varying_list_outputs = node_info.varying_list_outputs if mixed_list else set()
 
     init_params = ["self"]
     establish_links_params = []
@@ -192,6 +204,10 @@ def generate_node_class(node_info: NodeInfo, config: TreeTypeConfig) -> str:
             for key, cls in _OUTPUT_SOCKET_CLASSES.items():
                 if key in socket.bl_socket_type:
                     return_type = cls
+                    if "GRID" in socket.structure_type:
+                        return_type = return_type.replace("Socket", "SocketGrid")
+                    elif "LIST" in socket.structure_type:
+                        return_type = f"{return_type}List"
                     break
             attr_name = normalize_name(socket.identifier)
             desc = socket.description if socket.description else socket.name
@@ -215,7 +231,13 @@ def generate_node_class(node_info: NodeInfo, config: TreeTypeConfig) -> str:
         if inputs_generic and socket.identifier in varying_inputs:
             attr_name = normalize_name(socket.identifier)
             doc = socket.description or socket.name
-            ann = f"        {attr_name}: S"
+            if socket.identifier in varying_grid_inputs:
+                param = "SGrid"
+            elif socket.identifier in varying_list_inputs:
+                param = "SList"
+            else:
+                param = "S"
+            ann = f"        {attr_name}: {param}"
             if doc:
                 ann += f'\n        """{doc}"""'
             return ann
@@ -225,7 +247,13 @@ def generate_node_class(node_info: NodeInfo, config: TreeTypeConfig) -> str:
     input_annotations = [_input_annotation(socket) for socket in node_info.inputs] + [
         _input_annotation(socket) for socket in _extra_sockets
     ]
-    inputs_base = "[S](SocketAccessor)" if inputs_generic else "(SocketAccessor)"
+    if mixed_grid:
+        generic_base = "[S, SGrid](SocketAccessor)"
+    elif mixed_list:
+        generic_base = "[S, SList](SocketAccessor)"
+    else:
+        generic_base = "[S](SocketAccessor)"
+    inputs_base = generic_base if inputs_generic else "(SocketAccessor)"
     if input_annotations:
         inputs_class = f"    class _Inputs{inputs_base}:\n" + "\n".join(
             input_annotations
@@ -238,14 +266,20 @@ def generate_node_class(node_info: NodeInfo, config: TreeTypeConfig) -> str:
         if outputs_generic and socket.identifier in varying_outputs:
             attr_name = normalize_name(socket.identifier)
             doc = socket.description or socket.name
-            ann = f"        {attr_name}: S"
+            if socket.identifier in varying_grid_outputs:
+                param = "SGrid"
+            elif socket.identifier in varying_list_outputs:
+                param = "SList"
+            else:
+                param = "S"
+            ann = f"        {attr_name}: {param}"
             if doc:
                 ann += f'\n        """{doc}"""'
             output_annotations.append(ann)
         else:
             output_annotations.append(socket.format_accessor_annotation())
 
-    outputs_base = "[S](SocketAccessor)" if outputs_generic else "(SocketAccessor)"
+    outputs_base = generic_base if outputs_generic else "(SocketAccessor)"
     if output_annotations:
         outputs_class = f"    class _Outputs{outputs_base}:\n" + "\n".join(
             output_annotations
@@ -255,10 +289,16 @@ def generate_node_class(node_info: NodeInfo, config: TreeTypeConfig) -> str:
 
     # Prepend any registered mixin bases (listed first so they win via MRO).
     base_classes = list(custom.bases) if custom else []
-    type_params = "[T]" if is_generic else ""
+    if mixed_grid:
+        generic_args = "[T, TGrid]"
+    elif mixed_list:
+        generic_args = "[T, TList]"
+    else:
+        generic_args = "[T]"
+    type_params = generic_args if is_generic else ""
     class_base = type_params + "(" + ", ".join(base_classes + ["BaseNode"]) + ")"
-    o_return_type = "_Outputs[T]" if outputs_generic else "_Outputs"
-    i_return_type = "_Inputs[T]" if inputs_generic else "_Inputs"
+    o_return_type = f"_Outputs{generic_args}" if outputs_generic else "_Outputs"
+    i_return_type = f"_Inputs{generic_args}" if inputs_generic else "_Inputs"
 
     # When extra sockets exist, properties must be set before collecting socket IDs
     # so the node reflects the correct enum state when we filter key_args.

--- a/gen/introspect.py
+++ b/gen/introspect.py
@@ -28,6 +28,22 @@ def _collect_socket_menu_items(socket: bpy.types.NodeSocket) -> list[str]:
         return values
 
 
+def _socket_structure_type(socket: bpy.types.NodeSocket) -> str:
+    """The socket's structure type, honouring its *declared* grid-ness.
+
+    ``inferred_structure_type`` comes from Blender's link-based inference,
+    which reports SINGLE for an unlinked grid or list input (e.g. Set Grid
+    Background's Grid, List Length's List) — but such sockets always render
+    with the ``VOLUME_GRID``/``LIST`` display shape, so that is the reliable
+    declaration."""
+    display_shape = getattr(socket, "display_shape", "")
+    if display_shape == "VOLUME_GRID":
+        return "GRID"
+    if display_shape == "LIST":
+        return "LIST"
+    return getattr(socket, "inferred_structure_type", "")
+
+
 def collect_socket_info(
     sockets: bpy.types.bpy_prop_collection[bpy.types.NodeSocket],
     hidden=False,
@@ -57,7 +73,7 @@ def collect_socket_info(
             socket_type=socket.type,
             is_output=is_output,
             is_multi_input=getattr(socket, "is_multi_input", False),
-            structure_type=getattr(socket, "inferred_structure_type", ""),
+            structure_type=_socket_structure_type(socket),
             menu_items=_collect_socket_menu_items(socket)
             if socket.type == "MENU" and cast(Any, socket).default_value != ""
             else [],

--- a/gen/model.py
+++ b/gen/model.py
@@ -97,7 +97,7 @@ class SocketInfo:
                 if "GRID" in self.structure_type:
                     return _GRID_TYPE_MAP.get(item, item)
                 if "LIST" in self.structure_type:
-                    return item.replace("Input", "InputList")
+                    return f"{item}List"
                 return item
         raise KeyError(f"Couldnt match socket type {self.bl_socket_type}")
 
@@ -389,6 +389,56 @@ class NodeInfo:
         return True
 
     @property
+    def varying_grid_outputs(self) -> set[str]:
+        """Varying outputs that are grid-structured (their socket class is the
+        ``*SocketGrid`` variant of the bound type)."""
+        grid = {s.identifier for s in self.outputs if "GRID" in s.structure_type}
+        return self.varying_output_identifiers & grid
+
+    @property
+    def varying_grid_inputs(self) -> set[str]:
+        """Varying inputs that are grid-structured."""
+        grid = {s.identifier for s in self.inputs if "GRID" in s.structure_type}
+        return self.varying_input_identifiers & grid
+
+    @property
+    def generic_mixed_grid(self) -> bool:
+        """The generic type spans both grid and non-grid varying sockets
+        (e.g. Set Grid Background: Grid is ``FloatSocketGrid`` while
+        Background is ``FloatSocket``) — such classes take a second ``TGrid``
+        type parameter."""
+        grid = self.varying_grid_outputs | self.varying_grid_inputs
+        non_grid = (
+            self.varying_output_identifiers | self.varying_input_identifiers
+        ) - grid
+        return bool(grid) and bool(non_grid)
+
+    @property
+    def varying_list_outputs(self) -> set[str]:
+        """Varying outputs that are list-structured (their socket class is the
+        ``*SocketList`` variant of the bound type)."""
+        lists = {s.identifier for s in self.outputs if "LIST" in s.structure_type}
+        return self.varying_output_identifiers & lists
+
+    @property
+    def varying_list_inputs(self) -> set[str]:
+        """Varying inputs that are list-structured."""
+        lists = {s.identifier for s in self.inputs if "LIST" in s.structure_type}
+        return self.varying_input_identifiers & lists
+
+    @property
+    def generic_mixed_list(self) -> bool:
+        """The generic type spans both list and non-list varying sockets
+        (e.g. Get List Item: List is ``FloatSocketList`` while Value is
+        ``FloatSocket``) — such classes take a second ``TList`` type
+        parameter."""
+        lists = self.varying_list_outputs | self.varying_list_inputs
+        non_list = (
+            self.varying_output_identifiers | self.varying_input_identifiers
+        ) - lists
+        return bool(lists) and bool(non_list)
+
+    @property
     def outputs_generic(self) -> bool:
         """The output side is generic: ≥1 output varies and all varying outputs
         share a single type per enum value (so a single ``_S`` suffices)."""
@@ -404,10 +454,29 @@ class NodeInfo:
             self.varying_input_identifiers, outputs=False
         )
 
+    def _maybe_grid_class(
+        self, socket_identifier: str, cls_name: str, *, outputs: bool
+    ) -> str:
+        """The ``*SocketGrid``/``*SocketList`` variant when the socket is
+        grid- or list-structured."""
+        side = self.outputs if outputs else self.inputs
+        for s in side:
+            if s.identifier != socket_identifier:
+                continue
+            if "GRID" in s.structure_type:
+                return cls_name.replace("Socket", "SocketGrid")
+            if "LIST" in s.structure_type:
+                return f"{cls_name}List"
+        return cls_name
+
     def output_class_for_enum(
         self, socket_identifier: str, enum_identifier: str
     ) -> str:
         """Return the socket class name for a varying output given an enum identifier."""
+
+        def finish(cls: str) -> str:
+            return self._maybe_grid_class(socket_identifier, cls, outputs=True)
+
         for prop in self.properties:
             for enum in prop.enum_items:
                 if enum.identifier == enum_identifier:
@@ -415,18 +484,22 @@ class NodeInfo:
                         if s.identifier == socket_identifier:
                             for key, cls in _OUTPUT_SOCKET_CLASSES.items():
                                 if key in s.bl_socket_type:
-                                    return cls
+                                    return finish(cls)
         for s in self.outputs:
             if s.identifier == socket_identifier:
                 for key, cls in _OUTPUT_SOCKET_CLASSES.items():
                     if key in s.bl_socket_type:
-                        return cls
+                        return finish(cls)
         return "Socket"
 
     def input_class_for_enum(self, socket_identifier: str, enum_identifier: str) -> str:
         """Return the socket class name for a varying input given an enum
         identifier (mirrors :meth:`output_class_for_enum` for input-generic
         nodes like Compare)."""
+
+        def finish(cls: str) -> str:
+            return self._maybe_grid_class(socket_identifier, cls, outputs=False)
+
         for prop in self.properties:
             for enum in prop.enum_items:
                 if enum.identifier == enum_identifier:
@@ -434,12 +507,12 @@ class NodeInfo:
                         if s.identifier == socket_identifier:
                             for key, cls in _OUTPUT_SOCKET_CLASSES.items():
                                 if key in s.bl_socket_type:
-                                    return cls
+                                    return finish(cls)
         for s in self.inputs:
             if s.identifier == socket_identifier:
                 for key, cls in _OUTPUT_SOCKET_CLASSES.items():
                     if key in s.bl_socket_type:
-                        return cls
+                        return finish(cls)
         return "Socket"
 
     def generate_enum_class_methods(
@@ -514,8 +587,15 @@ class NodeInfo:
                         and param_name != ""
                         and param_name != normalize_name(prop.identifier)
                     ):
+                        # Grid/list-structured sockets have no scalar default.
+                        default = (
+                            "None"
+                            if "GRID" in socket.structure_type
+                            or "LIST" in socket.structure_type
+                            else format_python_value(socket.default_value)
+                        )
                         input_params.append(
-                            f"{param_name}: {socket.type_hint} = {format_python_value(socket.default_value)}"
+                            f"{param_name}: {socket.type_hint} = {default}"
                         )
                         # Use the same parameter name as in the constructor
                         call_params.append(f"{socket_name}={param_name}")
@@ -537,17 +617,30 @@ class NodeInfo:
                 # Parameterise the return type when the node is generic. The
                 # output side wins when present (Switch/Mix/field nodes); else
                 # the input side drives it (Compare, whose output is Boolean).
-                if self.outputs_generic:
-                    varying_id = next(iter(self.varying_output_identifiers))
-                    socket_cls = self.output_class_for_enum(varying_id, enum.identifier)
-                    return_type = f"{cls_name}[{socket_cls}]"
+                # Mixed grid/non-grid generics bind both parameters
+                # (``[FloatSocket, FloatSocketGrid]``).
+                if self.outputs_generic or self.inputs_generic:
+                    if self.outputs_generic:
+                        varying_id = next(iter(self.varying_output_identifiers))
+                        socket_cls = self.output_class_for_enum(
+                            varying_id, enum.identifier
+                        )
+                    else:
+                        varying_id = next(iter(self.varying_input_identifiers))
+                        socket_cls = self.input_class_for_enum(
+                            varying_id, enum.identifier
+                        )
+                    if self.generic_mixed_grid:
+                        base_cls = socket_cls.replace("SocketGrid", "Socket")
+                        grid_cls = base_cls.replace("Socket", "SocketGrid")
+                        return_type = f"{cls_name}[{base_cls}, {grid_cls}]"
+                    elif self.generic_mixed_list:
+                        base_cls = socket_cls.removesuffix("List")
+                        return_type = f"{cls_name}[{base_cls}, {base_cls}List]"
+                    else:
+                        return_type = f"{cls_name}[{socket_cls}]"
                     # Use the class name directly (not cls) so the type checker
                     # can resolve the parameterized return type.
-                    call_expr = f"{cls_name}({call_params_str})"
-                elif self.inputs_generic:
-                    varying_id = next(iter(self.varying_input_identifiers))
-                    socket_cls = self.input_class_for_enum(varying_id, enum.identifier)
-                    return_type = f"{cls_name}[{socket_cls}]"
                     call_expr = f"{cls_name}({call_params_str})"
                 else:
                     return_type = cls_name

--- a/gen/util.py
+++ b/gen/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import unicodedata
 from typing import TYPE_CHECKING, Any
 
 from bpy.types import VectorFont
@@ -15,8 +16,13 @@ def normalize_name(name: str) -> str:
 
     Handles numeric names by prefixing with 'input_' to make valid Python identifiers.
     """
+    # Fold accented letters to their ASCII base ('Bézier' → 'bezier') so
+    # generated method names stay plain-ASCII identifiers.
+    normalized = "".join(
+        c for c in unicodedata.normalize("NFKD", name) if not unicodedata.combining(c)
+    )
     # Replace spaces, hyphens, and other non-alphanumeric characters with underscores
-    normalized = name.lower()
+    normalized = normalized.lower()
     normalized = "".join(c if c.isalnum() else "_" for c in normalized)
 
     # Remove consecutive underscores and leading/trailing underscores

--- a/src/nodebpy/builder/_utils.py
+++ b/src/nodebpy/builder/_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import keyword
 import re
+import unicodedata
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import bpy
@@ -43,8 +44,12 @@ def normalize_name(name: str) -> str:
     """Convert 'Geometry' or 'My Socket' to a valid lower-case Python identifier
     ('geometry', 'my_socket'). Spaces, punctuation and other non-identifier
     characters (e.g. the '⟂'/'(' in 'BA⟂(BC)') collapse to underscores so the
-    result is always usable as an attribute or parameter name."""
-    text = name.lower().replace("é", "e")
+    result is always usable as an attribute or parameter name. Accented
+    letters fold to their ASCII base ('Bézier' → 'bezier') to match the
+    generated method names."""
+    text = "".join(
+        c for c in unicodedata.normalize("NFKD", name) if not unicodedata.combining(c)
+    ).lower()
     cleaned = _NON_IDENTIFIER.sub("_", text).strip("_")
     if cleaned and cleaned[0].isdigit():
         cleaned = "_" + cleaned

--- a/src/nodebpy/builder/socket.py
+++ b/src/nodebpy/builder/socket.py
@@ -405,25 +405,25 @@ class _FloatGridOperatorMixin(Socket):
         """Calculate the direction and magnitude of the change in values of a scalar grid."""
         from ..nodes.geometry import GridGradient
 
-        return GridGradient(self.socket).o.gradient
+        return GridGradient(self.socket).o.gradient  # ty: ignore[invalid-argument-type]
 
     def laplacian(self) -> FloatSocketGrid:
         """Compute the divergence of the gradient of the input grid."""
         from ..nodes.geometry import GridLaplacian
 
-        return GridLaplacian(self.socket).o.laplacian
+        return GridLaplacian(self.socket).o.laplacian  # ty: ignore[invalid-argument-type]
 
     def sdf_fillet(self, iterations: InputInteger = 1) -> FloatSocketGrid:
         """Round off concave internal corners in a signed distance field. Only affects areas with negative principal curvature, creating smoother transitions between surfaces."""
         from ..nodes.geometry import SDFGridFillet
 
-        return SDFGridFillet(self.socket, iterations=iterations).o.grid
+        return SDFGridFillet(self.socket, iterations=iterations).o.grid  # ty: ignore[invalid-argument-type]
 
     def sdf_laplacian(self, iterations: InputInteger = 1) -> FloatSocketGrid:
         """Apply Laplacian flow smoothing to a signed distance field. Computationally efficient alternative to mean curvature flow, ideal when combined with SDF normalization."""
         from ..nodes.geometry import SDFGridLaplacian
 
-        return SDFGridLaplacian(self.socket, iterations=iterations).o.grid
+        return SDFGridLaplacian(self.socket, iterations=iterations).o.grid  # ty: ignore[invalid-argument-type]
 
     def sdf_mean(
         self, width: InputInteger = 1, iterations: InputInteger = 1
@@ -431,13 +431,13 @@ class _FloatGridOperatorMixin(Socket):
         """Apply mean (box) filter smoothing to a signed distance field. Fast separable averaging filter for general smoothing of the distance field."""
         from ..nodes.geometry import SDFGridMean
 
-        return SDFGridMean(self.socket, width=width, iterations=iterations).o.grid
+        return SDFGridMean(self.socket, width=width, iterations=iterations).o.grid  # ty: ignore[invalid-argument-type]
 
     def sdf_mean_curvature(self, iterations: InputInteger = 1) -> FloatSocketGrid:
         """Apply mean curvature flow smoothing to a signed distance field. Evolves the surface based on its mean curvature, naturally smoothing high-curvature regions more than flat areas."""
         from ..nodes.geometry import SDFGridMeanCurvature
 
-        return SDFGridMeanCurvature(self.socket, iterations=iterations).o.grid
+        return SDFGridMeanCurvature(self.socket, iterations=iterations).o.grid  # ty: ignore[invalid-argument-type]
 
     def sdf_median(
         self, width: InputInteger = 1, iterations: InputInteger = 1
@@ -445,13 +445,13 @@ class _FloatGridOperatorMixin(Socket):
         """Apply median filter to a signed distance field. Reduces noise while preserving sharp features and edges in the distance field."""
         from ..nodes.geometry import SDFGridMedian
 
-        return SDFGridMedian(self.socket, width=width, iterations=iterations).o.grid
+        return SDFGridMedian(self.socket, width=width, iterations=iterations).o.grid  # ty: ignore[invalid-argument-type]
 
     def sdf_offset(self, distance: InputFloat = 0.1) -> FloatSocketGrid:
         """Offset a signed distance field surface by a world-space distance. Dilates (positive) or erodes (negative) while maintaining the signed distance property."""
         from ..nodes.geometry import SDFGridOffset
 
-        return SDFGridOffset(self.socket, distance=distance).o.grid
+        return SDFGridOffset(self.socket, distance=distance).o.grid  # ty: ignore[invalid-argument-type]
 
     def to_mesh(
         self, threshold: InputFloat = 0.1, adaptivity: InputFloat = 0.0
@@ -460,7 +460,9 @@ class _FloatGridOperatorMixin(Socket):
         from ..nodes.geometry import GridToMesh
 
         return GridToMesh(
-            self.socket, threshold=threshold, adaptivity=adaptivity
+            self.socket,  # ty: ignore[invalid-argument-type]
+            threshold=threshold,
+            adaptivity=adaptivity,
         ).o.mesh
 
 
@@ -469,13 +471,13 @@ class _VectorGridOperatorMixin(Socket):
         """Calculate the magnitude and direction of circulation of a directional vector grid."""
         from ..nodes.geometry import GridCurl
 
-        return GridCurl(self.socket).o.curl
+        return GridCurl(self.socket).o.curl  # ty: ignore[invalid-argument-type]
 
     def divergence(self) -> FloatSocketGrid:
         """Calculate the flow into and out of each point of a directional vector grid."""
         from ..nodes.geometry import GridDivergence
 
-        return GridDivergence(self.socket).o.divergence
+        return GridDivergence(self.socket).o.divergence  # ty: ignore[invalid-argument-type]
 
 
 # ---------------------------------------------------------------------------
@@ -483,8 +485,8 @@ class _VectorGridOperatorMixin(Socket):
 # ---------------------------------------------------------------------------
 
 
-class _GridSocketMixin[T](Socket):
-    def _info(self) -> GridInfo[T]:
+class _GridSocketMixin[T, TG](Socket):
+    def _info(self) -> GridInfo[T, TG]:
         from ..nodes.geometry import GridInfo
 
         self._assert_output("transform / background_value")
@@ -618,7 +620,7 @@ class _GridSocketMixin[T](Socket):
             data_type=self._socket_dtype,  # ty: ignore[invalid-argument-type]
         ).o.grid
 
-    def to_points(self) -> GridToPoints[T]:
+    def to_points(self) -> GridToPoints[T, TG]:
         """Generate a point cloud from a volume grid's active voxels."""
         from ..nodes.geometry import GridToPoints
 
@@ -2268,7 +2270,7 @@ class FloatSocketList(
 
 class FloatSocketGrid(
     _FloatMixin["IntegerSocketGrid"],
-    _GridSocketMixin[FloatSocket],
+    _GridSocketMixin[FloatSocket, "FloatSocketGrid"],
     _FloatGridOperatorMixin,
     _GridMeanMixin,
 ):
@@ -2353,7 +2355,7 @@ class VectorSocketList(
 
 class VectorSocketGrid(
     _VectorMixin,
-    _GridSocketMixin[VectorSocket],
+    _GridSocketMixin[VectorSocket, "VectorSocketGrid"],
     _VectorGridOperatorMixin,
     _GridMeanMixin,
 ):
@@ -2436,7 +2438,9 @@ class IntegerVectorSocket(
     """Runtime integer vector socket wrapper."""
 
 
-class IntegerSocketGrid(_IntegerMixin, _GridSocketMixin[IntegerSocket], _GridMeanMixin):
+class IntegerSocketGrid(
+    _IntegerMixin, _GridSocketMixin[IntegerSocket, "IntegerSocketGrid"], _GridMeanMixin
+):
     """Runtime integer grid socket wrapper."""
 
 
@@ -2487,7 +2491,9 @@ class BooleanSocketList(_BooleanMixin, _ListMixin[BooleanSocket]):
     """List of boolean sockets."""
 
 
-class BooleanSocketGrid(_BooleanMixin, _GridSocketMixin[BooleanSocket]):
+class BooleanSocketGrid(
+    _BooleanMixin, _GridSocketMixin[BooleanSocket, "BooleanSocketGrid"]
+):
     """Runtime boolean grid socket wrapper."""
 
 

--- a/src/nodebpy/export/codegen.py
+++ b/src/nodebpy/export/codegen.py
@@ -1484,11 +1484,32 @@ def _parse_factory_func(
     call = returns[0].value
     if not (isinstance(call.func, ast.Name) and call.func.id in ("cls", cls.__name__)):
         return None
-    if call.args:
-        return None
 
     props: dict[str, Any] = {}
     socket_params: dict[str, str] = {}
+    if call.args:
+        # Positional socket forwarding — ``return cls(value, group_index,
+        # data_type="FLOAT")`` — maps each bare-name argument to the
+        # constructor parameter at that position.
+        try:
+            init_params = [
+                param
+                for param in inspect.signature(cls.__init__).parameters.values()
+                if param.name != "self"
+                and param.kind
+                in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                )
+            ]
+        except (TypeError, ValueError):
+            return None
+        if len(call.args) > len(init_params):
+            return None
+        for arg, param in zip(call.args, init_params):
+            if not isinstance(arg, ast.Name):
+                return None
+            socket_params[_normalize(param.name)] = arg.id
     for kw in call.keywords:
         if kw.arg is None:
             return None  # **kwargs forwarding
@@ -1579,6 +1600,16 @@ def _factory_state_matches(node, props: dict[str, Any]) -> bool:
     return True
 
 
+# Factory-baked properties that define a node's *type signature* rather than
+# an operation choice. A factory baking only these is preferred even when
+# every baked value sits at its default — the data type is load-bearing, so
+# ``NamedAttribute.float(name)`` or ``FieldMinAndMax.point.float()`` reads
+# better than a bare constructor that leaves the type implicit. Factories
+# baking behavioural props (``operation``, ``mode``, …) keep requiring a
+# non-default state, as before.
+_TYPE_FACTORY_PROPS = frozenset({"data_type", "domain", "input_type", "socket_type"})
+
+
 def _factory_call(
     func_prefix: str,
     node,
@@ -1603,7 +1634,11 @@ def _factory_call(
         covered = {_normalize(key) for key in factory.props}
         if set(prop_values) - set(factory.props):
             continue  # leftover props can't be passed to the factory
-        if not (set(prop_values) or covered & set(socket_kwargs)):
+        if not (
+            (factory.props and set(factory.props) <= _TYPE_FACTORY_PROPS)
+            or set(prop_values)
+            or covered & set(socket_kwargs)
+        ):
             continue  # nothing gained over the plain constructor
 
         call_kwargs: dict[str, Expr] = {}

--- a/src/nodebpy/export/codegen.py
+++ b/src/nodebpy/export/codegen.py
@@ -1005,13 +1005,18 @@ class EmitContext:
             )
         return val
 
-    def upstream_expr(self, link: _Link) -> Expr:
-        """Expression referencing the source side of ``link``."""
+    def upstream_expr(self, link: _Link, *, pipeline: bool = False) -> Expr:
+        """Expression referencing the source side of ``link``.
+
+        ``pipeline`` marks a ``>>`` statement source: the arrow already
+        implies the node's primary output, so a multi-output node stays a
+        bare reference there instead of forcing ``.o.<name>``."""
         return _output_expr(
             self._resolve(link),
             link.from_node,
             link.from_socket,
             to_socket=link.to_socket,
+            pipeline=pipeline,
         )
 
     def socket_expr(self, link: _Link) -> Expr:
@@ -1214,15 +1219,48 @@ def _bare_resolves_elsewhere(from_node, from_socket, to_socket) -> bool:
     return candidates[best].identifier != from_socket.identifier
 
 
+def _needs_output_accessor(from_node, from_socket) -> bool:
+    """Whether a reference to ``from_socket`` must spell out ``.o.<name>``
+    even though it is the node's first output.
+
+    A node with several active outputs is referenced explicitly so no reader
+    has to know which one is the default — except a node's *sole* geometry
+    output: for a geometry consumer nothing else could be meant (Cube's Mesh
+    next to its UV Map), so the bare reference stays. Inactive sockets (the
+    dormant variants of enum-switched outputs) and ``__extend__`` virtual
+    sockets don't count — only what the reader sees in the editor."""
+    active = [
+        s
+        for s in from_node.outputs
+        if not getattr(s, "is_inactive", False) and "__extend__" not in s.identifier
+    ]
+    if len(active) <= 1:
+        return False
+    if from_socket.type == "GEOMETRY":
+        return sum(s.type == "GEOMETRY" for s in active) > 1
+    return True
+
+
 def _output_expr(
-    val: _Val, from_node, from_socket, *, to_socket=None, force_socket: bool = False
+    val: _Val,
+    from_node,
+    from_socket,
+    *,
+    to_socket=None,
+    force_socket: bool = False,
+    pipeline: bool = False,
 ) -> Expr:
     """Reference an output socket of an emitted value.
 
-    Node-valued expressions reference the first output bare (``noise``) and
-    others via ``.o.<name>``; ``force_socket`` adds the accessor even for the
-    first output. Socket-valued expressions are returned as-is, after
-    checking they represent the requested output.
+    Single-output node-valued expressions are referenced bare (``math``);
+    a node with several active outputs gets an explicit ``.o.<name>``
+    accessor so no reader has to know which output is the default
+    (SeparateMatrix's nine components read uniformly) — except in
+    ``pipeline`` position, where ``>>`` already implies the primary output,
+    and per :func:`_needs_output_accessor`'s sole-geometry-output rule.
+    ``force_socket`` adds the accessor even to a single-output node.
+    Socket-valued expressions are returned as-is, after checking they
+    represent the requested output.
 
     ``to_socket`` is the consumer-side socket of the link, used to detect the
     case where a bare reference would resolve to a *different* output than the
@@ -1251,6 +1289,7 @@ def _output_expr(
         not force_socket
         and from_node.outputs
         and from_node.outputs[0].identifier == from_socket.identifier
+        and (pipeline or not _needs_output_accessor(from_node, from_socket))
         and not _bare_resolves_elsewhere(from_node, from_socket, to_socket)
     ):
         return val.expr
@@ -3655,7 +3694,9 @@ def _emit_tree(node_tree, collector: _GroupCollector) -> _TreeEmission:
                 skip_input_id=chain_link.to_socket.identifier if chain_link else None,
             )
             expr: Expr = (
-                BinOp(">>", ctx.upstream_expr(chain_link), call) if chain_link else call
+                BinOp(">>", ctx.upstream_expr(chain_link, pipeline=True), call)
+                if chain_link
+                else call
             )
             val = _Val(expr)
 
@@ -3703,7 +3744,7 @@ def _emit_tree(node_tree, collector: _GroupCollector) -> _TreeEmission:
                     f"Group output socket '{link.to_socket.name}' has no "
                     "interface variable"
                 )
-            source = _output_expr(val, node, link.from_socket)
+            source = _output_expr(val, node, link.from_socket, pipeline=True)
             chain = BinOp(">>", source, out_ref.require_expr())
             width = _MAX_LINE_WIDTH - 4 * len(frame)
             tagged_body.extend(
@@ -3757,7 +3798,7 @@ def _emit_tree(node_tree, collector: _GroupCollector) -> _TreeEmission:
             raise CodegenError(
                 f"Group output socket '{link.to_socket.name}' has no interface variable"
             )
-        source = ctx.upstream_expr(link)
+        source = ctx.upstream_expr(link, pipeline=True)
         out_lines.extend(_stmt_lines(BinOp(">>", source, out_ref.require_expr())))
 
     return _TreeEmission(
@@ -4343,7 +4384,7 @@ def _emit_viewer(node, ctx: EmitContext) -> Expr | _Val | None:
         key=lambda link: order.get(link.to_socket.identifier, 0),
     )
     for link in links:
-        statement = BinOp(">>", ctx.upstream_expr(link), Ref(var))
+        statement = BinOp(">>", ctx.upstream_expr(link, pipeline=True), Ref(var))
         ctx.pending_lines.extend(_stmt_lines(statement))
     return _Val(None, outputs={})
 
@@ -4976,7 +5017,7 @@ def _emit_zone_output(node, ctx: EmitContext) -> _Val:
                 f"zone output node '{node.name}' has a link into "
                 f"'{link.to_socket.name}' with no emit target"
             )
-        statement = BinOp(">>", ctx.upstream_expr(link), target)
+        statement = BinOp(">>", ctx.upstream_expr(link, pipeline=True), target)
         ctx.pending_lines.extend(_stmt_lines(statement))
     return _Val(None, outputs=state.outputs)
 

--- a/src/nodebpy/export/codegen.py
+++ b/src/nodebpy/export/codegen.py
@@ -101,6 +101,17 @@ class Lit(Expr):
     def render(self) -> str:
         return _fmt(self.value)
 
+    @property
+    def prec(self) -> int:  # type: ignore[override]
+        # A float can format as a compound math-constant expression
+        # (``2 * math.pi``, ``math.tau / 3``), which must parenthesise like
+        # the operators in it; a bare ``math.e`` stays an atom.
+        if isinstance(self.value, float):
+            text = _fmt(self.value)
+            if "math." in text and " " in text:
+                return _BINOP_PREC["*"]
+        return _ATOM_PREC
+
 
 @dataclass
 class Ref(Expr):
@@ -322,13 +333,74 @@ def _stmt_lines(
 # ---------------------------------------------------------------------------
 
 
+def _within_one_ulp(candidate: float, f32) -> bool:
+    """Whether ``candidate`` lands on ``f32`` or its immediate float32
+    neighbour. One ULP is the round-off a value picks up crossing precisions
+    (an authored ``0.15`` surviving as ``0.14999999``), so snapping across it
+    restores the authored constant without moving any genuinely different
+    value."""
+    import numpy as np
+
+    c32 = np.float32(candidate)
+    return bool(c32 == f32 or np.nextafter(f32, c32) == c32)
+
+
+def _math_constant_expression(f32) -> str | None:
+    """A ``math.pi``/``math.tau``/``math.e`` expression for a rational
+    multiple of one of those constants, or None.
+
+    Constants authored as expressions (``2 * math.pi``, ``pi / 3``, ``tau``,
+    ``e``) survive in a blend only as float32 values; matching small-fraction
+    multiples (within one ULP) restores the readable form. Numerators up to 48
+    over denominators up to 12 cover the usual turns and subdivisions while
+    keeping a chance coincidence with an ordinary decimal essentially
+    impossible. An even multiple of pi renders in tau form (``math.tau``,
+    ``math.tau / 3``) — with the fraction reduced, halving the numerator is
+    always the simpler expression.
+    """
+    import math
+
+    magnitude = abs(float(f32))
+    if magnitude == 0.0:
+        return None
+    for name, const in (("pi", math.pi), ("e", math.e)):
+        for den in range(1, 13):
+            num = round(magnitude * den / const)
+            if not 1 <= num <= 48 or math.gcd(num, den) != 1:
+                continue
+            if not _within_one_ulp(num * const / den, abs(f32)):
+                continue
+            if name == "pi" and num % 2 == 0:
+                name, num = "tau", num // 2
+            expr = f"math.{name}" if num == 1 else f"{num} * math.{name}"
+            if den > 1:
+                expr = f"{expr} / {den}"
+            return f"-{expr}" if float(f32) < 0 else expr
+    return None
+
+
+def _group_digits(text: str) -> str:
+    """Underscore-group a positional float literal's integer part when it has
+    five or more digits (``10000.0`` → ``10_000.0``)."""
+    sign = ""
+    if text.startswith("-"):
+        sign, text = "-", text[1:]
+    int_part, dot, frac = text.partition(".")
+    if len(int_part) < 5:
+        return sign + text
+    return sign + f"{int(int_part):_}" + dot + frac
+
+
 def _fmt_float(value: float) -> str:
-    """Shortest literal that round-trips through float32.
+    """Shortest readable literal for a float32-backed value.
 
     Blender stores socket values as float32, so reading them back through
-    Python gives noisy float64 reprs (``0.10000000149011612``); the
-    shortest decimal that uniquely identifies the float32 (``0.1``)
-    rebuilds the identical socket value.
+    Python gives noisy float64 reprs (``0.10000000149011612``); the shortest
+    decimal that uniquely identifies the float32 (``0.1``) rebuilds the
+    identical socket value. On top of that, rational multiples of pi, tau
+    and e render as ``math.*`` expressions, a value one ULP off a much shorter decimal
+    snaps to it (``0.14999999`` → ``0.15``), and long integer parts get
+    underscore grouping (``-10_000.0``).
     """
     import math
 
@@ -341,7 +413,24 @@ def _fmt_float(value: float) -> str:
     f32 = np.float32(value)
     if float(f32) != value:
         return repr(value)  # genuine float64 — keep full precision
-    return np.format_float_positional(f32, unique=True, trim="0")
+    const_expr = _math_constant_expression(f32)
+    if const_expr is not None:
+        return const_expr
+    text = np.format_float_positional(f32, unique=True, trim="0")
+    # Snap to the shortest decimal within one ULP: fewer significant digits
+    # first, so ``0.14999999`` becomes ``0.15`` rather than ``0.1499999``.
+    digits = sum(c.isdigit() for c in text.lstrip("-0."))
+    for sig in range(1, digits):
+        candidate = float(f"%.{sig}g" % float(f32))
+        if not _within_one_ulp(candidate, f32):
+            continue
+        snapped = np.format_float_positional(
+            np.float32(candidate), unique=True, trim="0"
+        )
+        if len(snapped) < len(text):
+            text = snapped
+        break
+    return _group_digits(text)
 
 
 def _fmt(value: Any) -> str:
@@ -641,6 +730,11 @@ def _make_var(label: str, counter: dict[str, int]) -> str:
         base = f"n_{base}" if base else "node"
     if keyword.iskeyword(base) or base in ["g", "s", "c", "nodebpy"]:
         base = f"{base}_"
+    # Module names the generated code may import stay off-limits: a Math
+    # node named ``math`` would shadow ``import math`` (for ``math.pi``
+    # constants), so its variables run ``math_1``, ``math_2``, …
+    if base in ("math", "bpy") and base not in counter:
+        counter[base] = 0
     if base not in counter:
         counter[base] = 0
         return base
@@ -3452,6 +3546,9 @@ def to_python(
     # Datablock defaults (a Material/Object/Image socket value) render via
     # ``repr()`` as ``bpy.data.<collection>['name']``, so the module needs a
     # bare ``import bpy`` to resolve them on rebuild.
+    # Math-constant expressions (from _fmt_float) need the stdlib import.
+    if any(re.search(r"\bmath\.(pi|tau|e)\b", line) for line in lines):
+        lines.insert(0, "import math")
     if any("bpy.data." in line for line in lines):
         lines.insert(0, "import bpy")
     code = "\n".join(lines)

--- a/src/nodebpy/nodes/geometry/attribute.py
+++ b/src/nodebpy/nodes/geometry/attribute.py
@@ -269,7 +269,7 @@ class GetAttributeNames(BaseNode):
 
     Outputs
     -------
-    o.names : StringSocket
+    o.names : StringSocketList
         Names
     """
 

--- a/src/nodebpy/nodes/geometry/converter.py
+++ b/src/nodebpy/nodes/geometry/converter.py
@@ -7,45 +7,81 @@ import bpy
 from ...builder import BaseNode, SocketAccessor
 from ...builder.socket import (
     BooleanSocket,
+    BooleanSocketList,
     BundleSocket,
+    BundleSocketList,
     ClosureSocket,
+    ClosureSocketList,
     CollectionSocket,
+    CollectionSocketList,
     ColorSocket,
+    ColorSocketList,
     FloatSocket,
+    FloatSocketList,
     FontSocket,
+    FontSocketList,
     GeometrySocket,
+    GeometrySocketList,
     ImageSocket,
+    ImageSocketList,
     IntegerSocket,
+    IntegerSocketList,
     MaterialSocket,
+    MaterialSocketList,
     MatrixSocket,
+    MatrixSocketList,
     MenuSocket,
+    MenuSocketList,
     ObjectSocket,
+    ObjectSocketList,
     RotationSocket,
+    RotationSocketList,
     SoundSocket,
+    SoundSocketList,
     StringSocket,
     StringSocketList,
     VectorSocket,
+    VectorSocketList,
 )
 from ...types import (
     InputAny,
     InputBoolean,
+    InputBooleanList,
     InputBundle,
+    InputBundleList,
     InputClosure,
+    InputClosureList,
     InputCollection,
+    InputCollectionList,
     InputColor,
+    InputColorList,
     InputFloat,
+    InputFloatGrid,
+    InputFloatList,
     InputFont,
+    InputFontList,
     InputGeometry,
+    InputGeometryList,
     InputImage,
+    InputImageList,
     InputInteger,
+    InputIntegerList,
     InputMaterial,
+    InputMaterialList,
     InputMatrix,
+    InputMatrixList,
     InputMenu,
+    InputMenuList,
     InputObject,
+    InputObjectList,
     InputRotation,
+    InputRotationList,
     InputSound,
+    InputSoundList,
     InputString,
+    InputStringList,
     InputVector,
+    InputVectorList,
     _AttributeDomains,
 )
 from .._mixins import (
@@ -2212,23 +2248,23 @@ class FilterList[T](BaseNode):
 
     Parameters
     ----------
-    list : InputFloat
+    list : InputFloatList
         List
     selection : InputBoolean
         Selection
 
     Inputs
     ------
-    i.list : FloatSocket
+    i.list : FloatSocketList
         List
     i.selection : BooleanSocket
         Selection
 
     Outputs
     -------
-    o.selection : FloatSocket
+    o.selection : FloatSocketList
         Selection
-    o.inverted : FloatSocket
+    o.inverted : FloatSocketList
         Inverted
     """
 
@@ -2256,7 +2292,7 @@ class FilterList[T](BaseNode):
 
     def __init__(
         self,
-        list: InputAny = 0.0,
+        list: InputAny = None,
         selection: InputBoolean = True,
         *,
         socket_type: Literal[
@@ -2287,127 +2323,127 @@ class FilterList[T](BaseNode):
 
     @classmethod
     def float(
-        cls, list: InputFloat = 0.0, selection: InputBoolean = True
-    ) -> "FilterList[FloatSocket]":
+        cls, list: InputFloatList = None, selection: InputBoolean = True
+    ) -> "FilterList[FloatSocketList]":
         """Create Filter List with operation 'Float'."""
         return FilterList(socket_type="FLOAT", list=list, selection=selection)
 
     @classmethod
     def integer(
-        cls, list: InputInteger = 0, selection: InputBoolean = True
-    ) -> "FilterList[IntegerSocket]":
+        cls, list: InputIntegerList = None, selection: InputBoolean = True
+    ) -> "FilterList[IntegerSocketList]":
         """Create Filter List with operation 'Integer'."""
         return FilterList(socket_type="INT", list=list, selection=selection)
 
     @classmethod
     def boolean(
-        cls, list: InputBoolean = False, selection: InputBoolean = True
-    ) -> "FilterList[BooleanSocket]":
+        cls, list: InputBooleanList = None, selection: InputBoolean = True
+    ) -> "FilterList[BooleanSocketList]":
         """Create Filter List with operation 'Boolean'."""
         return FilterList(socket_type="BOOLEAN", list=list, selection=selection)
 
     @classmethod
     def vector(
-        cls, list: InputVector = None, selection: InputBoolean = True
-    ) -> "FilterList[VectorSocket]":
+        cls, list: InputVectorList = None, selection: InputBoolean = True
+    ) -> "FilterList[VectorSocketList]":
         """Create Filter List with operation 'Vector'."""
         return FilterList(socket_type="VECTOR", list=list, selection=selection)
 
     @classmethod
     def color(
-        cls, list: InputColor = None, selection: InputBoolean = True
-    ) -> "FilterList[ColorSocket]":
+        cls, list: InputColorList = None, selection: InputBoolean = True
+    ) -> "FilterList[ColorSocketList]":
         """Create Filter List with operation 'Color'."""
         return FilterList(socket_type="RGBA", list=list, selection=selection)
 
     @classmethod
     def rotation(
-        cls, list: InputRotation = None, selection: InputBoolean = True
-    ) -> "FilterList[RotationSocket]":
+        cls, list: InputRotationList = None, selection: InputBoolean = True
+    ) -> "FilterList[RotationSocketList]":
         """Create Filter List with operation 'Rotation'."""
         return FilterList(socket_type="ROTATION", list=list, selection=selection)
 
     @classmethod
     def matrix(
-        cls, list: InputMatrix = None, selection: InputBoolean = True
-    ) -> "FilterList[MatrixSocket]":
+        cls, list: InputMatrixList = None, selection: InputBoolean = True
+    ) -> "FilterList[MatrixSocketList]":
         """Create Filter List with operation 'Matrix'."""
         return FilterList(socket_type="MATRIX", list=list, selection=selection)
 
     @classmethod
     def string(
-        cls, list: InputString = "", selection: InputBoolean = True
-    ) -> "FilterList[StringSocket]":
+        cls, list: InputStringList = None, selection: InputBoolean = True
+    ) -> "FilterList[StringSocketList]":
         """Create Filter List with operation 'String'."""
         return FilterList(socket_type="STRING", list=list, selection=selection)
 
     @classmethod
     def menu(
-        cls, list: InputMenu = None, selection: InputBoolean = True
-    ) -> "FilterList[MenuSocket]":
+        cls, list: InputMenuList = None, selection: InputBoolean = True
+    ) -> "FilterList[MenuSocketList]":
         """Create Filter List with operation 'Menu'."""
         return FilterList(socket_type="MENU", list=list, selection=selection)
 
     @classmethod
     def object(
-        cls, list: InputObject = None, selection: InputBoolean = True
-    ) -> "FilterList[ObjectSocket]":
+        cls, list: InputObjectList = None, selection: InputBoolean = True
+    ) -> "FilterList[ObjectSocketList]":
         """Create Filter List with operation 'Object'."""
         return FilterList(socket_type="OBJECT", list=list, selection=selection)
 
     @classmethod
     def image(
-        cls, list: InputImage = None, selection: InputBoolean = True
-    ) -> "FilterList[ImageSocket]":
+        cls, list: InputImageList = None, selection: InputBoolean = True
+    ) -> "FilterList[ImageSocketList]":
         """Create Filter List with operation 'Image'."""
         return FilterList(socket_type="IMAGE", list=list, selection=selection)
 
     @classmethod
     def geometry(
-        cls, list: InputGeometry = None, selection: InputBoolean = True
-    ) -> "FilterList[GeometrySocket]":
+        cls, list: InputGeometryList = None, selection: InputBoolean = True
+    ) -> "FilterList[GeometrySocketList]":
         """Create Filter List with operation 'Geometry'."""
         return FilterList(socket_type="GEOMETRY", list=list, selection=selection)
 
     @classmethod
     def collection(
-        cls, list: InputCollection = None, selection: InputBoolean = True
-    ) -> "FilterList[CollectionSocket]":
+        cls, list: InputCollectionList = None, selection: InputBoolean = True
+    ) -> "FilterList[CollectionSocketList]":
         """Create Filter List with operation 'Collection'."""
         return FilterList(socket_type="COLLECTION", list=list, selection=selection)
 
     @classmethod
     def material(
-        cls, list: InputMaterial = None, selection: InputBoolean = True
-    ) -> "FilterList[MaterialSocket]":
+        cls, list: InputMaterialList = None, selection: InputBoolean = True
+    ) -> "FilterList[MaterialSocketList]":
         """Create Filter List with operation 'Material'."""
         return FilterList(socket_type="MATERIAL", list=list, selection=selection)
 
     @classmethod
     def bundle(
-        cls, list: InputBundle = None, selection: InputBoolean = True
-    ) -> "FilterList[BundleSocket]":
+        cls, list: InputBundleList = None, selection: InputBoolean = True
+    ) -> "FilterList[BundleSocketList]":
         """Create Filter List with operation 'Bundle'."""
         return FilterList(socket_type="BUNDLE", list=list, selection=selection)
 
     @classmethod
     def closure(
-        cls, list: InputClosure = None, selection: InputBoolean = True
-    ) -> "FilterList[ClosureSocket]":
+        cls, list: InputClosureList = None, selection: InputBoolean = True
+    ) -> "FilterList[ClosureSocketList]":
         """Create Filter List with operation 'Closure'."""
         return FilterList(socket_type="CLOSURE", list=list, selection=selection)
 
     @classmethod
     def font(
-        cls, list: InputFont = None, selection: InputBoolean = True
-    ) -> "FilterList[FontSocket]":
+        cls, list: InputFontList = None, selection: InputBoolean = True
+    ) -> "FilterList[FontSocketList]":
         """Create Filter List with operation 'Font'."""
         return FilterList(socket_type="FONT", list=list, selection=selection)
 
     @classmethod
     def sound(
-        cls, list: InputSound = None, selection: InputBoolean = True
-    ) -> "FilterList[SoundSocket]":
+        cls, list: InputSoundList = None, selection: InputBoolean = True
+    ) -> "FilterList[SoundSocketList]":
         """Create Filter List with operation 'Sound'."""
         return FilterList(socket_type="SOUND", list=list, selection=selection)
 
@@ -3070,20 +3106,20 @@ class GetBundleItem[T](BaseNode):
         self.node.structure_type = value
 
 
-class GetListItem[T](BaseNode):
+class GetListItem[T, TList](BaseNode):
     """
     Retrieve a value from a list
 
     Parameters
     ----------
-    list : InputFloat
+    list : InputFloatList
         List
     index : InputInteger
         Index
 
     Inputs
     ------
-    i.list : FloatSocket
+    i.list : FloatSocketList
         List
     i.index : IntegerSocket
         Index
@@ -3097,26 +3133,26 @@ class GetListItem[T](BaseNode):
     _bl_idname = "GeometryNodeListGetItem"
     node: bpy.types.GeometryNodeListGetItem
 
-    class _Inputs[S](SocketAccessor):
-        list: S
+    class _Inputs[S, SList](SocketAccessor):
+        list: SList
         """List"""
         index: IntegerSocket
         """Index"""
 
-    class _Outputs[S](SocketAccessor):
+    class _Outputs[S, SList](SocketAccessor):
         value: S
         """Value"""
 
     if TYPE_CHECKING:
 
         @property
-        def i(self) -> _Inputs[T]: ...
+        def i(self) -> _Inputs[T, TList]: ...
         @property
-        def o(self) -> _Outputs[T]: ...
+        def o(self) -> _Outputs[T, TList]: ...
 
     def __init__(
         self,
-        list: InputAny = 0.0,
+        list: InputAny = None,
         index: InputInteger = 0,
         *,
         socket_type: Literal[
@@ -3151,169 +3187,169 @@ class GetListItem[T](BaseNode):
 
     @classmethod
     def float(
-        cls, list: InputFloat = 0.0, index: InputInteger = 0
-    ) -> "GetListItem[FloatSocket]":
+        cls, list: InputFloatList = None, index: InputInteger = 0
+    ) -> "GetListItem[FloatSocket, FloatSocketList]":
         """Create Get List Item with operation 'Float'."""
         return GetListItem(socket_type="FLOAT", list=list, index=index)
 
     @classmethod
     def integer(
-        cls, list: InputInteger = 0, index: InputInteger = 0
-    ) -> "GetListItem[IntegerSocket]":
+        cls, list: InputIntegerList = None, index: InputInteger = 0
+    ) -> "GetListItem[IntegerSocket, IntegerSocketList]":
         """Create Get List Item with operation 'Integer'."""
         return GetListItem(socket_type="INT", list=list, index=index)
 
     @classmethod
     def boolean(
-        cls, list: InputBoolean = False, index: InputInteger = 0
-    ) -> "GetListItem[BooleanSocket]":
+        cls, list: InputBooleanList = None, index: InputInteger = 0
+    ) -> "GetListItem[BooleanSocket, BooleanSocketList]":
         """Create Get List Item with operation 'Boolean'."""
         return GetListItem(socket_type="BOOLEAN", list=list, index=index)
 
     @classmethod
     def vector(
-        cls, list: InputVector = None, index: InputInteger = 0
-    ) -> "GetListItem[VectorSocket]":
+        cls, list: InputVectorList = None, index: InputInteger = 0
+    ) -> "GetListItem[VectorSocket, VectorSocketList]":
         """Create Get List Item with operation 'Vector'."""
         return GetListItem(socket_type="VECTOR", list=list, index=index)
 
     @classmethod
     def color(
-        cls, list: InputColor = None, index: InputInteger = 0
-    ) -> "GetListItem[ColorSocket]":
+        cls, list: InputColorList = None, index: InputInteger = 0
+    ) -> "GetListItem[ColorSocket, ColorSocketList]":
         """Create Get List Item with operation 'Color'."""
         return GetListItem(socket_type="RGBA", list=list, index=index)
 
     @classmethod
     def rotation(
-        cls, list: InputRotation = None, index: InputInteger = 0
-    ) -> "GetListItem[RotationSocket]":
+        cls, list: InputRotationList = None, index: InputInteger = 0
+    ) -> "GetListItem[RotationSocket, RotationSocketList]":
         """Create Get List Item with operation 'Rotation'."""
         return GetListItem(socket_type="ROTATION", list=list, index=index)
 
     @classmethod
     def matrix(
-        cls, list: InputMatrix = None, index: InputInteger = 0
-    ) -> "GetListItem[MatrixSocket]":
+        cls, list: InputMatrixList = None, index: InputInteger = 0
+    ) -> "GetListItem[MatrixSocket, MatrixSocketList]":
         """Create Get List Item with operation 'Matrix'."""
         return GetListItem(socket_type="MATRIX", list=list, index=index)
 
     @classmethod
     def string(
-        cls, list: InputString = "", index: InputInteger = 0
-    ) -> "GetListItem[StringSocket]":
+        cls, list: InputStringList = None, index: InputInteger = 0
+    ) -> "GetListItem[StringSocket, StringSocketList]":
         """Create Get List Item with operation 'String'."""
         return GetListItem(socket_type="STRING", list=list, index=index)
 
     @classmethod
     def menu(
-        cls, list: InputMenu = None, index: InputInteger = 0
-    ) -> "GetListItem[MenuSocket]":
+        cls, list: InputMenuList = None, index: InputInteger = 0
+    ) -> "GetListItem[MenuSocket, MenuSocketList]":
         """Create Get List Item with operation 'Menu'."""
         return GetListItem(socket_type="MENU", list=list, index=index)
 
     @classmethod
     def object(
-        cls, list: InputObject = None, index: InputInteger = 0
-    ) -> "GetListItem[ObjectSocket]":
+        cls, list: InputObjectList = None, index: InputInteger = 0
+    ) -> "GetListItem[ObjectSocket, ObjectSocketList]":
         """Create Get List Item with operation 'Object'."""
         return GetListItem(socket_type="OBJECT", list=list, index=index)
 
     @classmethod
     def image(
-        cls, list: InputImage = None, index: InputInteger = 0
-    ) -> "GetListItem[ImageSocket]":
+        cls, list: InputImageList = None, index: InputInteger = 0
+    ) -> "GetListItem[ImageSocket, ImageSocketList]":
         """Create Get List Item with operation 'Image'."""
         return GetListItem(socket_type="IMAGE", list=list, index=index)
 
     @classmethod
     def geometry(
-        cls, list: InputGeometry = None, index: InputInteger = 0
-    ) -> "GetListItem[GeometrySocket]":
+        cls, list: InputGeometryList = None, index: InputInteger = 0
+    ) -> "GetListItem[GeometrySocket, GeometrySocketList]":
         """Create Get List Item with operation 'Geometry'."""
         return GetListItem(socket_type="GEOMETRY", list=list, index=index)
 
     @classmethod
     def collection(
-        cls, list: InputCollection = None, index: InputInteger = 0
-    ) -> "GetListItem[CollectionSocket]":
+        cls, list: InputCollectionList = None, index: InputInteger = 0
+    ) -> "GetListItem[CollectionSocket, CollectionSocketList]":
         """Create Get List Item with operation 'Collection'."""
         return GetListItem(socket_type="COLLECTION", list=list, index=index)
 
     @classmethod
     def material(
-        cls, list: InputMaterial = None, index: InputInteger = 0
-    ) -> "GetListItem[MaterialSocket]":
+        cls, list: InputMaterialList = None, index: InputInteger = 0
+    ) -> "GetListItem[MaterialSocket, MaterialSocketList]":
         """Create Get List Item with operation 'Material'."""
         return GetListItem(socket_type="MATERIAL", list=list, index=index)
 
     @classmethod
     def bundle(
-        cls, list: InputBundle = None, index: InputInteger = 0
-    ) -> "GetListItem[BundleSocket]":
+        cls, list: InputBundleList = None, index: InputInteger = 0
+    ) -> "GetListItem[BundleSocket, BundleSocketList]":
         """Create Get List Item with operation 'Bundle'."""
         return GetListItem(socket_type="BUNDLE", list=list, index=index)
 
     @classmethod
     def closure(
-        cls, list: InputClosure = None, index: InputInteger = 0
-    ) -> "GetListItem[ClosureSocket]":
+        cls, list: InputClosureList = None, index: InputInteger = 0
+    ) -> "GetListItem[ClosureSocket, ClosureSocketList]":
         """Create Get List Item with operation 'Closure'."""
         return GetListItem(socket_type="CLOSURE", list=list, index=index)
 
     @classmethod
     def font(
-        cls, list: InputFont = None, index: InputInteger = 0
-    ) -> "GetListItem[FontSocket]":
+        cls, list: InputFontList = None, index: InputInteger = 0
+    ) -> "GetListItem[FontSocket, FontSocketList]":
         """Create Get List Item with operation 'Font'."""
         return GetListItem(socket_type="FONT", list=list, index=index)
 
     @classmethod
     def sound(
-        cls, list: InputSound = None, index: InputInteger = 0
-    ) -> "GetListItem[SoundSocket]":
+        cls, list: InputSoundList = None, index: InputInteger = 0
+    ) -> "GetListItem[SoundSocket, SoundSocketList]":
         """Create Get List Item with operation 'Sound'."""
         return GetListItem(socket_type="SOUND", list=list, index=index)
 
     @classmethod
     def auto(
-        cls, list: InputFloat = 0.0, index: InputInteger = 0
-    ) -> "GetListItem[FloatSocket]":
+        cls, list: InputFloatList = None, index: InputInteger = 0
+    ) -> "GetListItem[FloatSocket, FloatSocketList]":
         """Create Get List Item with operation 'Auto'. Automatically detect a good structure type based on how the socket is used"""
         return GetListItem(structure_type="AUTO", list=list, index=index)
 
     @classmethod
     def dynamic(
-        cls, list: InputFloat = 0.0, index: InputInteger = 0
-    ) -> "GetListItem[FloatSocket]":
+        cls, list: InputFloatList = None, index: InputInteger = 0
+    ) -> "GetListItem[FloatSocket, FloatSocketList]":
         """Create Get List Item with operation 'Dynamic'. Socket can work with different kinds of structures"""
         return GetListItem(structure_type="DYNAMIC", list=list, index=index)
 
     @classmethod
     def field(
-        cls, list: InputFloat = 0.0, index: InputInteger = 0
-    ) -> "GetListItem[FloatSocket]":
+        cls, list: InputFloatList = None, index: InputInteger = 0
+    ) -> "GetListItem[FloatSocket, FloatSocketList]":
         """Create Get List Item with operation 'Field'. Socket expects a field"""
         return GetListItem(structure_type="FIELD", list=list, index=index)
 
     @classmethod
     def grid(
-        cls, list: InputFloat = 0.0, index: InputInteger = 0
-    ) -> "GetListItem[FloatSocket]":
+        cls, list: InputFloatList = None, index: InputInteger = 0
+    ) -> "GetListItem[FloatSocket, FloatSocketList]":
         """Create Get List Item with operation 'Grid'. Socket expects a grid"""
         return GetListItem(structure_type="GRID", list=list, index=index)
 
     @classmethod
     def list(
-        cls, list: InputFloat = 0.0, index: InputInteger = 0
-    ) -> "GetListItem[FloatSocket]":
+        cls, list: InputFloatList = None, index: InputInteger = 0
+    ) -> "GetListItem[FloatSocket, FloatSocketList]":
         """Create Get List Item with operation 'List'. Socket expects a list"""
         return GetListItem(structure_type="LIST", list=list, index=index)
 
     @classmethod
     def single(
-        cls, list: InputFloat = 0.0, index: InputInteger = 0
-    ) -> "GetListItem[FloatSocket]":
+        cls, list: InputFloatList = None, index: InputInteger = 0
+    ) -> "GetListItem[FloatSocket, FloatSocketList]":
         """Create Get List Item with operation 'Single'. Socket expects a single value"""
         return GetListItem(structure_type="SINGLE", list=list, index=index)
 
@@ -3413,7 +3449,7 @@ class GetNestedBundlePaths(BaseNode):
 
     Outputs
     -------
-    o.paths : StringSocket
+    o.paths : StringSocketList
         Paths
     """
 
@@ -4290,12 +4326,12 @@ class ListLength[T](BaseNode):
 
     Parameters
     ----------
-    list : InputFloat
+    list : InputFloatList
         List
 
     Inputs
     ------
-    i.list : FloatSocket
+    i.list : FloatSocketList
         List
 
     Outputs
@@ -4324,7 +4360,7 @@ class ListLength[T](BaseNode):
 
     def __init__(
         self,
-        list: InputAny = 0.0,
+        list: InputAny = None,
         *,
         data_type: Literal[
             "FLOAT",
@@ -4353,92 +4389,100 @@ class ListLength[T](BaseNode):
         self._establish_links(**key_args)
 
     @classmethod
-    def float(cls, list: InputFloat = 0.0) -> "ListLength[FloatSocket]":
+    def float(cls, list: InputFloatList = None) -> "ListLength[FloatSocketList]":
         """Create List Length with operation 'Float'."""
         return ListLength(data_type="FLOAT", list=list)
 
     @classmethod
-    def integer(cls, list: InputInteger = 0) -> "ListLength[IntegerSocket]":
+    def integer(cls, list: InputIntegerList = None) -> "ListLength[IntegerSocketList]":
         """Create List Length with operation 'Integer'."""
         return ListLength(data_type="INT", list=list)
 
     @classmethod
-    def boolean(cls, list: InputBoolean = False) -> "ListLength[BooleanSocket]":
+    def boolean(cls, list: InputBooleanList = None) -> "ListLength[BooleanSocketList]":
         """Create List Length with operation 'Boolean'."""
         return ListLength(data_type="BOOLEAN", list=list)
 
     @classmethod
-    def vector(cls, list: InputVector = None) -> "ListLength[VectorSocket]":
+    def vector(cls, list: InputVectorList = None) -> "ListLength[VectorSocketList]":
         """Create List Length with operation 'Vector'."""
         return ListLength(data_type="VECTOR", list=list)
 
     @classmethod
-    def color(cls, list: InputColor = None) -> "ListLength[ColorSocket]":
+    def color(cls, list: InputColorList = None) -> "ListLength[ColorSocketList]":
         """Create List Length with operation 'Color'."""
         return ListLength(data_type="RGBA", list=list)
 
     @classmethod
-    def rotation(cls, list: InputRotation = None) -> "ListLength[RotationSocket]":
+    def rotation(
+        cls, list: InputRotationList = None
+    ) -> "ListLength[RotationSocketList]":
         """Create List Length with operation 'Rotation'."""
         return ListLength(data_type="ROTATION", list=list)
 
     @classmethod
-    def matrix(cls, list: InputMatrix = None) -> "ListLength[MatrixSocket]":
+    def matrix(cls, list: InputMatrixList = None) -> "ListLength[MatrixSocketList]":
         """Create List Length with operation 'Matrix'."""
         return ListLength(data_type="MATRIX", list=list)
 
     @classmethod
-    def string(cls, list: InputString = "") -> "ListLength[StringSocket]":
+    def string(cls, list: InputStringList = None) -> "ListLength[StringSocketList]":
         """Create List Length with operation 'String'."""
         return ListLength(data_type="STRING", list=list)
 
     @classmethod
-    def menu(cls, list: InputMenu = None) -> "ListLength[MenuSocket]":
+    def menu(cls, list: InputMenuList = None) -> "ListLength[MenuSocketList]":
         """Create List Length with operation 'Menu'."""
         return ListLength(data_type="MENU", list=list)
 
     @classmethod
-    def object(cls, list: InputObject = None) -> "ListLength[ObjectSocket]":
+    def object(cls, list: InputObjectList = None) -> "ListLength[ObjectSocketList]":
         """Create List Length with operation 'Object'."""
         return ListLength(data_type="OBJECT", list=list)
 
     @classmethod
-    def image(cls, list: InputImage = None) -> "ListLength[ImageSocket]":
+    def image(cls, list: InputImageList = None) -> "ListLength[ImageSocketList]":
         """Create List Length with operation 'Image'."""
         return ListLength(data_type="IMAGE", list=list)
 
     @classmethod
-    def geometry(cls, list: InputGeometry = None) -> "ListLength[GeometrySocket]":
+    def geometry(
+        cls, list: InputGeometryList = None
+    ) -> "ListLength[GeometrySocketList]":
         """Create List Length with operation 'Geometry'."""
         return ListLength(data_type="GEOMETRY", list=list)
 
     @classmethod
-    def collection(cls, list: InputCollection = None) -> "ListLength[CollectionSocket]":
+    def collection(
+        cls, list: InputCollectionList = None
+    ) -> "ListLength[CollectionSocketList]":
         """Create List Length with operation 'Collection'."""
         return ListLength(data_type="COLLECTION", list=list)
 
     @classmethod
-    def material(cls, list: InputMaterial = None) -> "ListLength[MaterialSocket]":
+    def material(
+        cls, list: InputMaterialList = None
+    ) -> "ListLength[MaterialSocketList]":
         """Create List Length with operation 'Material'."""
         return ListLength(data_type="MATERIAL", list=list)
 
     @classmethod
-    def bundle(cls, list: InputBundle = None) -> "ListLength[BundleSocket]":
+    def bundle(cls, list: InputBundleList = None) -> "ListLength[BundleSocketList]":
         """Create List Length with operation 'Bundle'."""
         return ListLength(data_type="BUNDLE", list=list)
 
     @classmethod
-    def closure(cls, list: InputClosure = None) -> "ListLength[ClosureSocket]":
+    def closure(cls, list: InputClosureList = None) -> "ListLength[ClosureSocketList]":
         """Create List Length with operation 'Closure'."""
         return ListLength(data_type="CLOSURE", list=list)
 
     @classmethod
-    def font(cls, list: InputFont = None) -> "ListLength[FontSocket]":
+    def font(cls, list: InputFontList = None) -> "ListLength[FontSocketList]":
         """Create List Length with operation 'Font'."""
         return ListLength(data_type="FONT", list=list)
 
     @classmethod
-    def sound(cls, list: InputSound = None) -> "ListLength[SoundSocket]":
+    def sound(cls, list: InputSoundList = None) -> "ListLength[SoundSocketList]":
         """Create List Length with operation 'Sound'."""
         return ListLength(data_type="SOUND", list=list)
 
@@ -6896,7 +6940,7 @@ class SortList[T](BaseNode):
 
     Parameters
     ----------
-    list : InputFloat
+    list : InputFloatList
         List
     selection : InputBoolean
         Selection
@@ -6907,7 +6951,7 @@ class SortList[T](BaseNode):
 
     Inputs
     ------
-    i.list : FloatSocket
+    i.list : FloatSocketList
         List
     i.selection : BooleanSocket
         Selection
@@ -6918,7 +6962,7 @@ class SortList[T](BaseNode):
 
     Outputs
     -------
-    o.list : FloatSocket
+    o.list : FloatSocketList
         List
     """
 
@@ -6948,7 +6992,7 @@ class SortList[T](BaseNode):
 
     def __init__(
         self,
-        list: InputAny = 0.0,
+        list: InputAny = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
@@ -6987,11 +7031,11 @@ class SortList[T](BaseNode):
     @classmethod
     def float(
         cls,
-        list: InputFloat = 0.0,
+        list: InputFloatList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[FloatSocket]":
+    ) -> "SortList[FloatSocketList]":
         """Create Sort List with operation 'Float'."""
         return SortList(
             socket_type="FLOAT",
@@ -7004,11 +7048,11 @@ class SortList[T](BaseNode):
     @classmethod
     def integer(
         cls,
-        list: InputInteger = 0,
+        list: InputIntegerList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[IntegerSocket]":
+    ) -> "SortList[IntegerSocketList]":
         """Create Sort List with operation 'Integer'."""
         return SortList(
             socket_type="INT",
@@ -7021,11 +7065,11 @@ class SortList[T](BaseNode):
     @classmethod
     def boolean(
         cls,
-        list: InputBoolean = False,
+        list: InputBooleanList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[BooleanSocket]":
+    ) -> "SortList[BooleanSocketList]":
         """Create Sort List with operation 'Boolean'."""
         return SortList(
             socket_type="BOOLEAN",
@@ -7038,11 +7082,11 @@ class SortList[T](BaseNode):
     @classmethod
     def vector(
         cls,
-        list: InputVector = None,
+        list: InputVectorList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[VectorSocket]":
+    ) -> "SortList[VectorSocketList]":
         """Create Sort List with operation 'Vector'."""
         return SortList(
             socket_type="VECTOR",
@@ -7055,11 +7099,11 @@ class SortList[T](BaseNode):
     @classmethod
     def color(
         cls,
-        list: InputColor = None,
+        list: InputColorList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[ColorSocket]":
+    ) -> "SortList[ColorSocketList]":
         """Create Sort List with operation 'Color'."""
         return SortList(
             socket_type="RGBA",
@@ -7072,11 +7116,11 @@ class SortList[T](BaseNode):
     @classmethod
     def rotation(
         cls,
-        list: InputRotation = None,
+        list: InputRotationList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[RotationSocket]":
+    ) -> "SortList[RotationSocketList]":
         """Create Sort List with operation 'Rotation'."""
         return SortList(
             socket_type="ROTATION",
@@ -7089,11 +7133,11 @@ class SortList[T](BaseNode):
     @classmethod
     def matrix(
         cls,
-        list: InputMatrix = None,
+        list: InputMatrixList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[MatrixSocket]":
+    ) -> "SortList[MatrixSocketList]":
         """Create Sort List with operation 'Matrix'."""
         return SortList(
             socket_type="MATRIX",
@@ -7106,11 +7150,11 @@ class SortList[T](BaseNode):
     @classmethod
     def string(
         cls,
-        list: InputString = "",
+        list: InputStringList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[StringSocket]":
+    ) -> "SortList[StringSocketList]":
         """Create Sort List with operation 'String'."""
         return SortList(
             socket_type="STRING",
@@ -7123,11 +7167,11 @@ class SortList[T](BaseNode):
     @classmethod
     def menu(
         cls,
-        list: InputMenu = None,
+        list: InputMenuList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[MenuSocket]":
+    ) -> "SortList[MenuSocketList]":
         """Create Sort List with operation 'Menu'."""
         return SortList(
             socket_type="MENU",
@@ -7140,11 +7184,11 @@ class SortList[T](BaseNode):
     @classmethod
     def object(
         cls,
-        list: InputObject = None,
+        list: InputObjectList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[ObjectSocket]":
+    ) -> "SortList[ObjectSocketList]":
         """Create Sort List with operation 'Object'."""
         return SortList(
             socket_type="OBJECT",
@@ -7157,11 +7201,11 @@ class SortList[T](BaseNode):
     @classmethod
     def image(
         cls,
-        list: InputImage = None,
+        list: InputImageList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[ImageSocket]":
+    ) -> "SortList[ImageSocketList]":
         """Create Sort List with operation 'Image'."""
         return SortList(
             socket_type="IMAGE",
@@ -7174,11 +7218,11 @@ class SortList[T](BaseNode):
     @classmethod
     def geometry(
         cls,
-        list: InputGeometry = None,
+        list: InputGeometryList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[GeometrySocket]":
+    ) -> "SortList[GeometrySocketList]":
         """Create Sort List with operation 'Geometry'."""
         return SortList(
             socket_type="GEOMETRY",
@@ -7191,11 +7235,11 @@ class SortList[T](BaseNode):
     @classmethod
     def collection(
         cls,
-        list: InputCollection = None,
+        list: InputCollectionList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[CollectionSocket]":
+    ) -> "SortList[CollectionSocketList]":
         """Create Sort List with operation 'Collection'."""
         return SortList(
             socket_type="COLLECTION",
@@ -7208,11 +7252,11 @@ class SortList[T](BaseNode):
     @classmethod
     def material(
         cls,
-        list: InputMaterial = None,
+        list: InputMaterialList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[MaterialSocket]":
+    ) -> "SortList[MaterialSocketList]":
         """Create Sort List with operation 'Material'."""
         return SortList(
             socket_type="MATERIAL",
@@ -7225,11 +7269,11 @@ class SortList[T](BaseNode):
     @classmethod
     def bundle(
         cls,
-        list: InputBundle = None,
+        list: InputBundleList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[BundleSocket]":
+    ) -> "SortList[BundleSocketList]":
         """Create Sort List with operation 'Bundle'."""
         return SortList(
             socket_type="BUNDLE",
@@ -7242,11 +7286,11 @@ class SortList[T](BaseNode):
     @classmethod
     def closure(
         cls,
-        list: InputClosure = None,
+        list: InputClosureList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[ClosureSocket]":
+    ) -> "SortList[ClosureSocketList]":
         """Create Sort List with operation 'Closure'."""
         return SortList(
             socket_type="CLOSURE",
@@ -7259,11 +7303,11 @@ class SortList[T](BaseNode):
     @classmethod
     def font(
         cls,
-        list: InputFont = None,
+        list: InputFontList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[FontSocket]":
+    ) -> "SortList[FontSocketList]":
         """Create Sort List with operation 'Font'."""
         return SortList(
             socket_type="FONT",
@@ -7276,11 +7320,11 @@ class SortList[T](BaseNode):
     @classmethod
     def sound(
         cls,
-        list: InputSound = None,
+        list: InputSoundList = None,
         selection: InputBoolean = True,
         group_id: InputInteger = 0,
         sort_weight: InputFloat = 0.0,
-    ) -> "SortList[SoundSocket]":
+    ) -> "SortList[SoundSocketList]":
         """Create Sort List with operation 'Sound'."""
         return SortList(
             socket_type="SOUND",
@@ -7362,7 +7406,7 @@ class SplitString(BaseNode):
 
     Outputs
     -------
-    o.list : StringSocket
+    o.list : StringSocketList
         List
     """
 
@@ -7690,7 +7734,10 @@ class StoreBundleItem[T](BaseNode):
 
     @classmethod
     def grid(
-        cls, bundle: InputBundle = None, path: InputString = "", item: InputFloat = 0.0
+        cls,
+        bundle: InputBundle = None,
+        path: InputString = "",
+        item: InputFloatGrid = None,
     ) -> "StoreBundleItem[FloatSocket]":
         """Create Store Bundle Item with operation 'Grid'. Socket expects a grid"""
         return StoreBundleItem(
@@ -7699,7 +7746,10 @@ class StoreBundleItem[T](BaseNode):
 
     @classmethod
     def list(
-        cls, bundle: InputBundle = None, path: InputString = "", item: InputFloat = 0.0
+        cls,
+        bundle: InputBundle = None,
+        path: InputString = "",
+        item: InputFloatList = None,
     ) -> "StoreBundleItem[FloatSocket]":
         """Create Store Bundle Item with operation 'List'. Socket expects a list"""
         return StoreBundleItem(
@@ -8227,14 +8277,14 @@ class TagFilter(BaseNode):
     ----------
     tag_filter : InputString
         Tag Filter
-    tags : InputString
+    tags : InputStringList
         Tags
 
     Inputs
     ------
     i.tag_filter : StringSocket
         Tag Filter
-    i.tags : StringSocket
+    i.tags : StringSocketList
         Tags
 
     Outputs
@@ -8249,7 +8299,7 @@ class TagFilter(BaseNode):
     class _Inputs(SocketAccessor):
         tag_filter: StringSocket
         """Tag Filter"""
-        tags: StringSocket
+        tags: StringSocketList
         """Tags"""
 
     class _Outputs(SocketAccessor):
@@ -8266,7 +8316,7 @@ class TagFilter(BaseNode):
     def __init__(
         self,
         tag_filter: InputString = "",
-        tags: InputString = "",
+        tags: InputStringList = None,
     ):
         super().__init__()
         key_args = {"Tag Filter": tag_filter, "Tags": tags}

--- a/src/nodebpy/nodes/geometry/geometry.py
+++ b/src/nodebpy/nodes/geometry/geometry.py
@@ -35,6 +35,7 @@ from ...types import (
     InputMenu,
     InputRotation,
     InputString,
+    InputStringList,
     InputVector,
 )
 from .._mixins import _BakeMixin, _HandleModeMixin
@@ -9134,7 +9135,7 @@ class TransferAttributes(BaseNode):
         Source Instance ID
     pattern_mode : InputMenu | Literal['Exact', 'Wildcard']
         Pattern Mode
-    attribute_names : InputString
+    attribute_names : InputStringList
         Attribute Names
     exclude_names : InputBoolean
         Exclude Names
@@ -9171,7 +9172,7 @@ class TransferAttributes(BaseNode):
         Source Instance ID
     i.pattern_mode : MenuSocket
         Pattern Mode
-    i.attribute_names : StringSocket
+    i.attribute_names : StringSocketList
         Attribute Names
     i.exclude_names : BooleanSocket
         Exclude Names
@@ -9180,7 +9181,7 @@ class TransferAttributes(BaseNode):
     -------
     o.target : GeometrySocket
         Target
-    o.transferred_names : StringSocket
+    o.transferred_names : StringSocketList
         Transferred Names
     """
 
@@ -9218,7 +9219,7 @@ class TransferAttributes(BaseNode):
         """Source Instance ID"""
         pattern_mode: MenuSocket
         """Pattern Mode"""
-        attribute_names: StringSocket
+        attribute_names: StringSocketList
         """Attribute Names"""
         exclude_names: BooleanSocket
         """Exclude Names"""
@@ -9253,7 +9254,7 @@ class TransferAttributes(BaseNode):
         source_curve_id: InputInteger = 0,
         source_instance_id: InputInteger = 0,
         pattern_mode: InputMenu | Literal["Exact", "Wildcard"] = "Wildcard",
-        attribute_names: InputString = "",
+        attribute_names: InputStringList = None,
         exclude_names: InputBoolean = False,
     ):
         super().__init__()

--- a/src/nodebpy/nodes/geometry/geometry.py
+++ b/src/nodebpy/nodes/geometry/geometry.py
@@ -8141,7 +8141,7 @@ class SetSplineType(BaseNode):
         return cls(spline_type="POLY", curve=curve, selection=selection)
 
     @classmethod
-    def bézier(
+    def bezier(
         cls, curve: InputGeometry = None, selection: InputBoolean = True
     ) -> "SetSplineType":
         """Create Set Spline Type with operation 'Bézier'."""

--- a/src/nodebpy/nodes/geometry/grid.py
+++ b/src/nodebpy/nodes/geometry/grid.py
@@ -12,6 +12,7 @@ from ...builder.socket import (
     FloatSocketGrid,
     GeometrySocket,
     IntegerSocket,
+    IntegerSocketGrid,
     MatrixSocket,
     MenuSocket,
     StringSocket,
@@ -21,13 +22,17 @@ from ...builder.socket import (
 from ...types import (
     InputAny,
     InputBoolean,
+    InputBooleanGrid,
     InputFloat,
+    InputFloatGrid,
     InputGeometry,
     InputInteger,
+    InputIntegerGrid,
     InputMatrix,
     InputMenu,
     InputString,
     InputVector,
+    InputVectorGrid,
 )
 
 
@@ -37,9 +42,9 @@ class AdvectGrid[T](BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
-    velocity : InputVector
+    velocity : InputVectorGrid
         Velocity
     time_step : InputFloat
         Time Step
@@ -50,9 +55,9 @@ class AdvectGrid[T](BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
-    i.velocity : VectorSocket
+    i.velocity : VectorSocketGrid
         Velocity
     i.time_step : FloatSocket
         Time Step
@@ -63,7 +68,7 @@ class AdvectGrid[T](BaseNode):
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -73,7 +78,7 @@ class AdvectGrid[T](BaseNode):
     class _Inputs[S](SocketAccessor):
         grid: S
         """Grid"""
-        velocity: VectorSocket
+        velocity: VectorSocketGrid
         """Velocity"""
         time_step: FloatSocket
         """Time Step"""
@@ -95,8 +100,8 @@ class AdvectGrid[T](BaseNode):
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
-        velocity: InputVector = None,
+        grid: InputAny = None,
+        velocity: InputVectorGrid = None,
         time_step: InputFloat = 1.0,
         integration_scheme: InputMenu
         | Literal[
@@ -125,8 +130,8 @@ class AdvectGrid[T](BaseNode):
     @classmethod
     def float(
         cls,
-        grid: InputFloat = 0.0,
-        velocity: InputVector = None,
+        grid: InputFloatGrid = None,
+        velocity: InputVectorGrid = None,
         time_step: InputFloat = 1.0,
         integration_scheme: InputMenu
         | Literal[
@@ -138,7 +143,7 @@ class AdvectGrid[T](BaseNode):
             "BFECC",
         ] = "Runge-Kutta 3",
         limiter: InputMenu | Literal["None", "Clamp", "Revert"] = "Clamp",
-    ) -> "AdvectGrid[FloatSocket]":
+    ) -> "AdvectGrid[FloatSocketGrid]":
         """Create Advect Grid with operation 'Float'."""
         return AdvectGrid(
             data_type="FLOAT",
@@ -152,8 +157,8 @@ class AdvectGrid[T](BaseNode):
     @classmethod
     def integer(
         cls,
-        grid: InputInteger = 0,
-        velocity: InputVector = None,
+        grid: InputIntegerGrid = None,
+        velocity: InputVectorGrid = None,
         time_step: InputFloat = 1.0,
         integration_scheme: InputMenu
         | Literal[
@@ -165,7 +170,7 @@ class AdvectGrid[T](BaseNode):
             "BFECC",
         ] = "Runge-Kutta 3",
         limiter: InputMenu | Literal["None", "Clamp", "Revert"] = "Clamp",
-    ) -> "AdvectGrid[IntegerSocket]":
+    ) -> "AdvectGrid[IntegerSocketGrid]":
         """Create Advect Grid with operation 'Integer'."""
         return AdvectGrid(
             data_type="INT",
@@ -179,8 +184,8 @@ class AdvectGrid[T](BaseNode):
     @classmethod
     def vector(
         cls,
-        grid: InputVector = None,
-        velocity: InputVector = None,
+        grid: InputVectorGrid = None,
+        velocity: InputVectorGrid = None,
         time_step: InputFloat = 1.0,
         integration_scheme: InputMenu
         | Literal[
@@ -192,7 +197,7 @@ class AdvectGrid[T](BaseNode):
             "BFECC",
         ] = "Runge-Kutta 3",
         limiter: InputMenu | Literal["None", "Clamp", "Revert"] = "Clamp",
-    ) -> "AdvectGrid[VectorSocket]":
+    ) -> "AdvectGrid[VectorSocketGrid]":
         """Create Advect Grid with operation 'Vector'."""
         return AdvectGrid(
             data_type="VECTOR",
@@ -218,7 +223,7 @@ class ClipGrid[T](BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     min_x : InputInteger
         Min X
@@ -235,7 +240,7 @@ class ClipGrid[T](BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.min_x : IntegerSocket
         Min X
@@ -252,7 +257,7 @@ class ClipGrid[T](BaseNode):
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -288,7 +293,7 @@ class ClipGrid[T](BaseNode):
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         min_x: InputInteger = 0,
         min_y: InputInteger = 0,
         min_z: InputInteger = 0,
@@ -314,14 +319,14 @@ class ClipGrid[T](BaseNode):
     @classmethod
     def float(
         cls,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         min_x: InputInteger = 0,
         min_y: InputInteger = 0,
         min_z: InputInteger = 0,
         max_x: InputInteger = 32,
         max_y: InputInteger = 32,
         max_z: InputInteger = 32,
-    ) -> "ClipGrid[FloatSocket]":
+    ) -> "ClipGrid[FloatSocketGrid]":
         """Create Clip Grid with operation 'Float'."""
         return ClipGrid(
             data_type="FLOAT",
@@ -337,14 +342,14 @@ class ClipGrid[T](BaseNode):
     @classmethod
     def integer(
         cls,
-        grid: InputInteger = 0,
+        grid: InputIntegerGrid = None,
         min_x: InputInteger = 0,
         min_y: InputInteger = 0,
         min_z: InputInteger = 0,
         max_x: InputInteger = 32,
         max_y: InputInteger = 32,
         max_z: InputInteger = 32,
-    ) -> "ClipGrid[IntegerSocket]":
+    ) -> "ClipGrid[IntegerSocketGrid]":
         """Create Clip Grid with operation 'Integer'."""
         return ClipGrid(
             data_type="INT",
@@ -360,14 +365,14 @@ class ClipGrid[T](BaseNode):
     @classmethod
     def boolean(
         cls,
-        grid: InputBoolean = False,
+        grid: InputBooleanGrid = None,
         min_x: InputInteger = 0,
         min_y: InputInteger = 0,
         min_z: InputInteger = 0,
         max_x: InputInteger = 32,
         max_y: InputInteger = 32,
         max_z: InputInteger = 32,
-    ) -> "ClipGrid[BooleanSocket]":
+    ) -> "ClipGrid[BooleanSocketGrid]":
         """Create Clip Grid with operation 'Boolean'."""
         return ClipGrid(
             data_type="BOOLEAN",
@@ -383,14 +388,14 @@ class ClipGrid[T](BaseNode):
     @classmethod
     def vector(
         cls,
-        grid: InputVector = None,
+        grid: InputVectorGrid = None,
         min_x: InputInteger = 0,
         min_y: InputInteger = 0,
         min_z: InputInteger = 0,
         max_x: InputInteger = 32,
         max_y: InputInteger = 32,
         max_z: InputInteger = 32,
-    ) -> "ClipGrid[VectorSocket]":
+    ) -> "ClipGrid[VectorSocketGrid]":
         """Create Clip Grid with operation 'Vector'."""
         return ClipGrid(
             data_type="VECTOR",
@@ -456,7 +461,7 @@ class CubeGridTopology(BaseNode):
 
     Outputs
     -------
-    o.topology : BooleanSocket
+    o.topology : BooleanSocketGrid
         Topology
     """
 
@@ -524,7 +529,7 @@ class DistributePointsInGrid(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     density : InputFloat
         Density
@@ -537,7 +542,7 @@ class DistributePointsInGrid(BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.density : FloatSocket
         Density
@@ -558,7 +563,7 @@ class DistributePointsInGrid(BaseNode):
     node: bpy.types.GeometryNodeDistributePointsInGrid
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
         density: FloatSocket
         """Density"""
@@ -582,7 +587,7 @@ class DistributePointsInGrid(BaseNode):
 
     def __init__(
         self,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         density: InputFloat = 1.0,
         seed: InputInteger = 0,
         spacing: InputVector = None,
@@ -603,7 +608,10 @@ class DistributePointsInGrid(BaseNode):
 
     @classmethod
     def random(
-        cls, grid: InputFloat = 0.0, density: InputFloat = 1.0, seed: InputInteger = 0
+        cls,
+        grid: InputFloatGrid = None,
+        density: InputFloat = 1.0,
+        seed: InputInteger = 0,
     ) -> "DistributePointsInGrid":
         """Create Distribute Points in Grid with operation 'Random'. Distribute points randomly inside of the volume"""
         return cls(mode="DENSITY_RANDOM", grid=grid, density=density, seed=seed)
@@ -611,7 +619,7 @@ class DistributePointsInGrid(BaseNode):
     @classmethod
     def grid(
         cls,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         spacing: InputVector = None,
         threshold: InputFloat = 0.1,
     ) -> "DistributePointsInGrid":
@@ -743,7 +751,7 @@ class GetNamedGrid[T](BaseNode):
     -------
     o.volume : GeometrySocket
         Volume
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -790,7 +798,7 @@ class GetNamedGrid[T](BaseNode):
         volume: InputGeometry = None,
         name: InputString = "",
         remove: InputBoolean = True,
-    ) -> "GetNamedGrid[FloatSocket]":
+    ) -> "GetNamedGrid[FloatSocketGrid]":
         """Create Get Named Grid with operation 'Float'."""
         return GetNamedGrid(data_type="FLOAT", volume=volume, name=name, remove=remove)
 
@@ -800,7 +808,7 @@ class GetNamedGrid[T](BaseNode):
         volume: InputGeometry = None,
         name: InputString = "",
         remove: InputBoolean = True,
-    ) -> "GetNamedGrid[IntegerSocket]":
+    ) -> "GetNamedGrid[IntegerSocketGrid]":
         """Create Get Named Grid with operation 'Integer'."""
         return GetNamedGrid(data_type="INT", volume=volume, name=name, remove=remove)
 
@@ -810,7 +818,7 @@ class GetNamedGrid[T](BaseNode):
         volume: InputGeometry = None,
         name: InputString = "",
         remove: InputBoolean = True,
-    ) -> "GetNamedGrid[BooleanSocket]":
+    ) -> "GetNamedGrid[BooleanSocketGrid]":
         """Create Get Named Grid with operation 'Boolean'."""
         return GetNamedGrid(
             data_type="BOOLEAN", volume=volume, name=name, remove=remove
@@ -822,7 +830,7 @@ class GetNamedGrid[T](BaseNode):
         volume: InputGeometry = None,
         name: InputString = "",
         remove: InputBoolean = True,
-    ) -> "GetNamedGrid[VectorSocket]":
+    ) -> "GetNamedGrid[VectorSocketGrid]":
         """Create Get Named Grid with operation 'Vector'."""
         return GetNamedGrid(data_type="VECTOR", volume=volume, name=name, remove=remove)
 
@@ -841,17 +849,17 @@ class GridCurl(BaseNode):
 
     Parameters
     ----------
-    grid : InputVector
+    grid : InputVectorGrid
         Grid
 
     Inputs
     ------
-    i.grid : VectorSocket
+    i.grid : VectorSocketGrid
         Grid
 
     Outputs
     -------
-    o.curl : VectorSocket
+    o.curl : VectorSocketGrid
         Curl
     """
 
@@ -859,7 +867,7 @@ class GridCurl(BaseNode):
     node: bpy.types.GeometryNodeGridCurl
 
     class _Inputs(SocketAccessor):
-        grid: VectorSocket
+        grid: VectorSocketGrid
         """Grid"""
 
     class _Outputs(SocketAccessor):
@@ -873,7 +881,7 @@ class GridCurl(BaseNode):
         @property
         def o(self) -> _Outputs: ...
 
-    def __init__(self, grid: InputVector = None):
+    def __init__(self, grid: InputVectorGrid = None):
         super().__init__()
         key_args = {"Grid": grid}
 
@@ -886,7 +894,7 @@ class GridDilateErode[T](BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     connectivity : InputMenu | Literal['Face', 'Edge', 'Vertex']
         Connectivity
@@ -897,7 +905,7 @@ class GridDilateErode[T](BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.connectivity : MenuSocket
         Connectivity
@@ -908,7 +916,7 @@ class GridDilateErode[T](BaseNode):
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -938,7 +946,7 @@ class GridDilateErode[T](BaseNode):
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         connectivity: InputMenu | Literal["Face", "Edge", "Vertex"] = "Face",
         tiles: InputMenu | Literal["Ignore", "Expand", "Preserve"] = "Preserve",
         steps: InputInteger = 1,
@@ -958,11 +966,11 @@ class GridDilateErode[T](BaseNode):
     @classmethod
     def float(
         cls,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         connectivity: InputMenu | Literal["Face", "Edge", "Vertex"] = "Face",
         tiles: InputMenu | Literal["Ignore", "Expand", "Preserve"] = "Preserve",
         steps: InputInteger = 1,
-    ) -> "GridDilateErode[FloatSocket]":
+    ) -> "GridDilateErode[FloatSocketGrid]":
         """Create Grid Dilate & Erode with operation 'Float'."""
         return GridDilateErode(
             data_type="FLOAT",
@@ -975,11 +983,11 @@ class GridDilateErode[T](BaseNode):
     @classmethod
     def integer(
         cls,
-        grid: InputInteger = 0,
+        grid: InputIntegerGrid = None,
         connectivity: InputMenu | Literal["Face", "Edge", "Vertex"] = "Face",
         tiles: InputMenu | Literal["Ignore", "Expand", "Preserve"] = "Preserve",
         steps: InputInteger = 1,
-    ) -> "GridDilateErode[IntegerSocket]":
+    ) -> "GridDilateErode[IntegerSocketGrid]":
         """Create Grid Dilate & Erode with operation 'Integer'."""
         return GridDilateErode(
             data_type="INT",
@@ -992,11 +1000,11 @@ class GridDilateErode[T](BaseNode):
     @classmethod
     def boolean(
         cls,
-        grid: InputBoolean = False,
+        grid: InputBooleanGrid = None,
         connectivity: InputMenu | Literal["Face", "Edge", "Vertex"] = "Face",
         tiles: InputMenu | Literal["Ignore", "Expand", "Preserve"] = "Preserve",
         steps: InputInteger = 1,
-    ) -> "GridDilateErode[BooleanSocket]":
+    ) -> "GridDilateErode[BooleanSocketGrid]":
         """Create Grid Dilate & Erode with operation 'Boolean'."""
         return GridDilateErode(
             data_type="BOOLEAN",
@@ -1009,11 +1017,11 @@ class GridDilateErode[T](BaseNode):
     @classmethod
     def vector(
         cls,
-        grid: InputVector = None,
+        grid: InputVectorGrid = None,
         connectivity: InputMenu | Literal["Face", "Edge", "Vertex"] = "Face",
         tiles: InputMenu | Literal["Ignore", "Expand", "Preserve"] = "Preserve",
         steps: InputInteger = 1,
-    ) -> "GridDilateErode[VectorSocket]":
+    ) -> "GridDilateErode[VectorSocketGrid]":
         """Create Grid Dilate & Erode with operation 'Vector'."""
         return GridDilateErode(
             data_type="VECTOR",
@@ -1038,17 +1046,17 @@ class GridDivergence(BaseNode):
 
     Parameters
     ----------
-    grid : InputVector
+    grid : InputVectorGrid
         Grid
 
     Inputs
     ------
-    i.grid : VectorSocket
+    i.grid : VectorSocketGrid
         Grid
 
     Outputs
     -------
-    o.divergence : FloatSocket
+    o.divergence : FloatSocketGrid
         Divergence
     """
 
@@ -1056,7 +1064,7 @@ class GridDivergence(BaseNode):
     node: bpy.types.GeometryNodeGridDivergence
 
     class _Inputs(SocketAccessor):
-        grid: VectorSocket
+        grid: VectorSocketGrid
         """Grid"""
 
     class _Outputs(SocketAccessor):
@@ -1070,7 +1078,7 @@ class GridDivergence(BaseNode):
         @property
         def o(self) -> _Outputs: ...
 
-    def __init__(self, grid: InputVector = None):
+    def __init__(self, grid: InputVectorGrid = None):
         super().__init__()
         key_args = {"Grid": grid}
 
@@ -1083,17 +1091,17 @@ class GridGradient(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
 
     Outputs
     -------
-    o.gradient : VectorSocket
+    o.gradient : VectorSocketGrid
         Gradient
     """
 
@@ -1101,7 +1109,7 @@ class GridGradient(BaseNode):
     node: bpy.types.GeometryNodeGridGradient
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
 
     class _Outputs(SocketAccessor):
@@ -1115,25 +1123,25 @@ class GridGradient(BaseNode):
         @property
         def o(self) -> _Outputs: ...
 
-    def __init__(self, grid: InputFloat = 0.0):
+    def __init__(self, grid: InputFloatGrid = None):
         super().__init__()
         key_args = {"Grid": grid}
 
         self._establish_links(**key_args)
 
 
-class GridInfo[T](BaseNode):
+class GridInfo[T, TGrid](BaseNode):
     """
     Retrieve information about a volume grid
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
 
     Outputs
@@ -1147,11 +1155,11 @@ class GridInfo[T](BaseNode):
     _bl_idname = "GeometryNodeGridInfo"
     node: bpy.types.GeometryNodeGridInfo
 
-    class _Inputs[S](SocketAccessor):
-        grid: S
+    class _Inputs[S, SGrid](SocketAccessor):
+        grid: SGrid
         """Grid"""
 
-    class _Outputs[S](SocketAccessor):
+    class _Outputs[S, SGrid](SocketAccessor):
         transform: MatrixSocket
         """Transform"""
         background_value: S
@@ -1160,13 +1168,13 @@ class GridInfo[T](BaseNode):
     if TYPE_CHECKING:
 
         @property
-        def i(self) -> _Inputs[T]: ...
+        def i(self) -> _Inputs[T, TGrid]: ...
         @property
-        def o(self) -> _Outputs[T]: ...
+        def o(self) -> _Outputs[T, TGrid]: ...
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         *,
         data_type: Literal["FLOAT", "INT", "BOOLEAN", "VECTOR"] = "FLOAT",
     ):
@@ -1176,22 +1184,30 @@ class GridInfo[T](BaseNode):
         self._establish_links(**key_args)
 
     @classmethod
-    def float(cls, grid: InputFloat = 0.0) -> "GridInfo[FloatSocket]":
+    def float(
+        cls, grid: InputFloatGrid = None
+    ) -> "GridInfo[FloatSocket, FloatSocketGrid]":
         """Create Grid Info with operation 'Float'."""
         return GridInfo(data_type="FLOAT", grid=grid)
 
     @classmethod
-    def integer(cls, grid: InputInteger = 0) -> "GridInfo[IntegerSocket]":
+    def integer(
+        cls, grid: InputIntegerGrid = None
+    ) -> "GridInfo[IntegerSocket, IntegerSocketGrid]":
         """Create Grid Info with operation 'Integer'."""
         return GridInfo(data_type="INT", grid=grid)
 
     @classmethod
-    def boolean(cls, grid: InputBoolean = False) -> "GridInfo[BooleanSocket]":
+    def boolean(
+        cls, grid: InputBooleanGrid = None
+    ) -> "GridInfo[BooleanSocket, BooleanSocketGrid]":
         """Create Grid Info with operation 'Boolean'."""
         return GridInfo(data_type="BOOLEAN", grid=grid)
 
     @classmethod
-    def vector(cls, grid: InputVector = None) -> "GridInfo[VectorSocket]":
+    def vector(
+        cls, grid: InputVectorGrid = None
+    ) -> "GridInfo[VectorSocket, VectorSocketGrid]":
         """Create Grid Info with operation 'Vector'."""
         return GridInfo(data_type="VECTOR", grid=grid)
 
@@ -1210,17 +1226,17 @@ class GridLaplacian(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
 
     Outputs
     -------
-    o.laplacian : FloatSocket
+    o.laplacian : FloatSocketGrid
         Laplacian
     """
 
@@ -1228,7 +1244,7 @@ class GridLaplacian(BaseNode):
     node: bpy.types.GeometryNodeGridLaplacian
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
 
     class _Outputs(SocketAccessor):
@@ -1242,7 +1258,7 @@ class GridLaplacian(BaseNode):
         @property
         def o(self) -> _Outputs: ...
 
-    def __init__(self, grid: InputFloat = 0.0):
+    def __init__(self, grid: InputFloatGrid = None):
         super().__init__()
         key_args = {"Grid": grid}
 
@@ -1255,7 +1271,7 @@ class GridMean[T](BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     width : InputInteger
         Width
@@ -1264,7 +1280,7 @@ class GridMean[T](BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.width : IntegerSocket
         Width
@@ -1273,7 +1289,7 @@ class GridMean[T](BaseNode):
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -1301,7 +1317,7 @@ class GridMean[T](BaseNode):
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
         *,
@@ -1315,10 +1331,10 @@ class GridMean[T](BaseNode):
     @classmethod
     def float(
         cls,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
-    ) -> "GridMean[FloatSocket]":
+    ) -> "GridMean[FloatSocketGrid]":
         """Create Grid Mean with operation 'Float'."""
         return GridMean(
             data_type="FLOAT", grid=grid, width=width, iterations=iterations
@@ -1327,20 +1343,20 @@ class GridMean[T](BaseNode):
     @classmethod
     def integer(
         cls,
-        grid: InputInteger = 0,
+        grid: InputIntegerGrid = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
-    ) -> "GridMean[IntegerSocket]":
+    ) -> "GridMean[IntegerSocketGrid]":
         """Create Grid Mean with operation 'Integer'."""
         return GridMean(data_type="INT", grid=grid, width=width, iterations=iterations)
 
     @classmethod
     def vector(
         cls,
-        grid: InputVector = None,
+        grid: InputVectorGrid = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
-    ) -> "GridMean[VectorSocket]":
+    ) -> "GridMean[VectorSocketGrid]":
         """Create Grid Mean with operation 'Vector'."""
         return GridMean(
             data_type="VECTOR", grid=grid, width=width, iterations=iterations
@@ -1361,7 +1377,7 @@ class GridMedian[T](BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     width : InputInteger
         Width
@@ -1370,7 +1386,7 @@ class GridMedian[T](BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.width : IntegerSocket
         Width
@@ -1379,7 +1395,7 @@ class GridMedian[T](BaseNode):
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -1407,7 +1423,7 @@ class GridMedian[T](BaseNode):
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
         *,
@@ -1421,10 +1437,10 @@ class GridMedian[T](BaseNode):
     @classmethod
     def float(
         cls,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
-    ) -> "GridMedian[FloatSocket]":
+    ) -> "GridMedian[FloatSocketGrid]":
         """Create Grid Median with operation 'Float'."""
         return GridMedian(
             data_type="FLOAT", grid=grid, width=width, iterations=iterations
@@ -1433,10 +1449,10 @@ class GridMedian[T](BaseNode):
     @classmethod
     def integer(
         cls,
-        grid: InputInteger = 0,
+        grid: InputIntegerGrid = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
-    ) -> "GridMedian[IntegerSocket]":
+    ) -> "GridMedian[IntegerSocketGrid]":
         """Create Grid Median with operation 'Integer'."""
         return GridMedian(
             data_type="INT", grid=grid, width=width, iterations=iterations
@@ -1445,10 +1461,10 @@ class GridMedian[T](BaseNode):
     @classmethod
     def vector(
         cls,
-        grid: InputVector = None,
+        grid: InputVectorGrid = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
-    ) -> "GridMedian[VectorSocket]":
+    ) -> "GridMedian[VectorSocketGrid]":
         """Create Grid Median with operation 'Vector'."""
         return GridMedian(
             data_type="VECTOR", grid=grid, width=width, iterations=iterations
@@ -1469,7 +1485,7 @@ class GridToMesh(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     threshold : InputFloat
         Threshold
@@ -1478,7 +1494,7 @@ class GridToMesh(BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.threshold : FloatSocket
         Threshold
@@ -1495,7 +1511,7 @@ class GridToMesh(BaseNode):
     node: bpy.types.GeometryNodeGridToMesh
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
         threshold: FloatSocket
         """Threshold"""
@@ -1515,7 +1531,7 @@ class GridToMesh(BaseNode):
 
     def __init__(
         self,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         threshold: InputFloat = 0.1,
         adaptivity: InputFloat = 0.0,
     ):
@@ -1525,18 +1541,18 @@ class GridToMesh(BaseNode):
         self._establish_links(**key_args)
 
 
-class GridToPoints[T](BaseNode):
+class GridToPoints[T, TGrid](BaseNode):
     """
     Generate a point cloud from a volume grid's active voxels
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
 
     Outputs
@@ -1560,11 +1576,11 @@ class GridToPoints[T](BaseNode):
     _bl_idname = "GeometryNodeGridToPoints"
     node: bpy.types.GeometryNodeGridToPoints
 
-    class _Inputs[S](SocketAccessor):
-        grid: S
+    class _Inputs[S, SGrid](SocketAccessor):
+        grid: SGrid
         """Grid"""
 
-    class _Outputs[S](SocketAccessor):
+    class _Outputs[S, SGrid](SocketAccessor):
         points: GeometrySocket
         """Points"""
         value: S
@@ -1583,13 +1599,13 @@ class GridToPoints[T](BaseNode):
     if TYPE_CHECKING:
 
         @property
-        def i(self) -> _Inputs[T]: ...
+        def i(self) -> _Inputs[T, TGrid]: ...
         @property
-        def o(self) -> _Outputs[T]: ...
+        def o(self) -> _Outputs[T, TGrid]: ...
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         *,
         data_type: Literal["FLOAT", "INT", "BOOLEAN", "VECTOR"] = "FLOAT",
     ):
@@ -1599,22 +1615,30 @@ class GridToPoints[T](BaseNode):
         self._establish_links(**key_args)
 
     @classmethod
-    def float(cls, grid: InputFloat = 0.0) -> "GridToPoints[FloatSocket]":
+    def float(
+        cls, grid: InputFloatGrid = None
+    ) -> "GridToPoints[FloatSocket, FloatSocketGrid]":
         """Create Grid to Points with operation 'Float'."""
         return GridToPoints(data_type="FLOAT", grid=grid)
 
     @classmethod
-    def integer(cls, grid: InputInteger = 0) -> "GridToPoints[IntegerSocket]":
+    def integer(
+        cls, grid: InputIntegerGrid = None
+    ) -> "GridToPoints[IntegerSocket, IntegerSocketGrid]":
         """Create Grid to Points with operation 'Integer'."""
         return GridToPoints(data_type="INT", grid=grid)
 
     @classmethod
-    def boolean(cls, grid: InputBoolean = False) -> "GridToPoints[BooleanSocket]":
+    def boolean(
+        cls, grid: InputBooleanGrid = None
+    ) -> "GridToPoints[BooleanSocket, BooleanSocketGrid]":
         """Create Grid to Points with operation 'Boolean'."""
         return GridToPoints(data_type="BOOLEAN", grid=grid)
 
     @classmethod
-    def vector(cls, grid: InputVector = None) -> "GridToPoints[VectorSocket]":
+    def vector(
+        cls, grid: InputVectorGrid = None
+    ) -> "GridToPoints[VectorSocket, VectorSocketGrid]":
         """Create Grid to Points with operation 'Vector'."""
         return GridToPoints(data_type="VECTOR", grid=grid)
 
@@ -1655,7 +1679,7 @@ class MeshToDensityGrid(BaseNode):
 
     Outputs
     -------
-    o.density_grid : FloatSocket
+    o.density_grid : FloatSocketGrid
         Density Grid
     """
 
@@ -1725,7 +1749,7 @@ class MeshToSDFGrid(BaseNode):
 
     Outputs
     -------
-    o.sdf_grid : FloatSocket
+    o.sdf_grid : FloatSocketGrid
         SDF Grid
     """
 
@@ -1877,7 +1901,7 @@ class PointsToSDFGrid(BaseNode):
 
     Outputs
     -------
-    o.sdf_grid : FloatSocket
+    o.sdf_grid : FloatSocketGrid
         SDF Grid
     """
 
@@ -2005,13 +2029,13 @@ class PointsToVolume(BaseNode):
         self._establish_links(**key_args)
 
 
-class PruneGrid[T](BaseNode):
+class PruneGrid[T, TGrid](BaseNode):
     """
     Make the storage of a volume grid more efficient by collapsing data into tiles or inner nodes
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     mode : InputMenu | Literal['Inactive', 'Threshold', 'SDF']
         Mode
@@ -2020,7 +2044,7 @@ class PruneGrid[T](BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.mode : MenuSocket
         Mode
@@ -2029,35 +2053,35 @@ class PruneGrid[T](BaseNode):
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
     _bl_idname = "GeometryNodeGridPrune"
     node: bpy.types.GeometryNodeGridPrune
 
-    class _Inputs[S](SocketAccessor):
-        grid: S
+    class _Inputs[S, SGrid](SocketAccessor):
+        grid: SGrid
         """Grid"""
         mode: MenuSocket
         """Mode"""
         threshold: S
         """Threshold"""
 
-    class _Outputs[S](SocketAccessor):
-        grid: S
+    class _Outputs[S, SGrid](SocketAccessor):
+        grid: SGrid
         """Grid"""
 
     if TYPE_CHECKING:
 
         @property
-        def i(self) -> _Inputs[T]: ...
+        def i(self) -> _Inputs[T, TGrid]: ...
         @property
-        def o(self) -> _Outputs[T]: ...
+        def o(self) -> _Outputs[T, TGrid]: ...
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         mode: InputMenu | Literal["Inactive", "Threshold", "SDF"] = "Threshold",
         threshold: InputAny = 0.01,
         *,
@@ -2071,39 +2095,39 @@ class PruneGrid[T](BaseNode):
     @classmethod
     def float(
         cls,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         mode: InputMenu | Literal["Inactive", "Threshold", "SDF"] = "Threshold",
         threshold: InputFloat = 0.01,
-    ) -> "PruneGrid[FloatSocket]":
+    ) -> "PruneGrid[FloatSocket, FloatSocketGrid]":
         """Create Prune Grid with operation 'Float'."""
         return PruneGrid(data_type="FLOAT", grid=grid, mode=mode, threshold=threshold)
 
     @classmethod
     def integer(
         cls,
-        grid: InputInteger = 0,
+        grid: InputIntegerGrid = None,
         mode: InputMenu | Literal["Inactive", "Threshold", "SDF"] = "Threshold",
         threshold: InputInteger = 0,
-    ) -> "PruneGrid[IntegerSocket]":
+    ) -> "PruneGrid[IntegerSocket, IntegerSocketGrid]":
         """Create Prune Grid with operation 'Integer'."""
         return PruneGrid(data_type="INT", grid=grid, mode=mode, threshold=threshold)
 
     @classmethod
     def boolean(
         cls,
-        grid: InputBoolean = False,
+        grid: InputBooleanGrid = None,
         mode: InputMenu | Literal["Inactive", "Threshold", "SDF"] = "Threshold",
-    ) -> "PruneGrid[BooleanSocket]":
+    ) -> "PruneGrid[BooleanSocket, BooleanSocketGrid]":
         """Create Prune Grid with operation 'Boolean'."""
         return PruneGrid(data_type="BOOLEAN", grid=grid, mode=mode)
 
     @classmethod
     def vector(
         cls,
-        grid: InputVector = None,
+        grid: InputVectorGrid = None,
         mode: InputMenu | Literal["Inactive", "Threshold", "SDF"] = "Threshold",
         threshold: InputVector = None,
-    ) -> "PruneGrid[VectorSocket]":
+    ) -> "PruneGrid[VectorSocket, VectorSocketGrid]":
         """Create Prune Grid with operation 'Vector'."""
         return PruneGrid(data_type="VECTOR", grid=grid, mode=mode, threshold=threshold)
 
@@ -2122,21 +2146,21 @@ class SDFGridFillet(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     iterations : InputInteger
         Iterations
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.iterations : IntegerSocket
         Iterations
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -2144,7 +2168,7 @@ class SDFGridFillet(BaseNode):
     node: bpy.types.GeometryNodeSDFGridFillet
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
         iterations: IntegerSocket
         """Iterations"""
@@ -2162,7 +2186,7 @@ class SDFGridFillet(BaseNode):
 
     def __init__(
         self,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         iterations: InputInteger = 1,
     ):
         super().__init__()
@@ -2177,21 +2201,21 @@ class SDFGridLaplacian(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     iterations : InputInteger
         Iterations
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.iterations : IntegerSocket
         Iterations
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -2199,7 +2223,7 @@ class SDFGridLaplacian(BaseNode):
     node: bpy.types.GeometryNodeSDFGridLaplacian
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
         iterations: IntegerSocket
         """Iterations"""
@@ -2217,7 +2241,7 @@ class SDFGridLaplacian(BaseNode):
 
     def __init__(
         self,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         iterations: InputInteger = 1,
     ):
         super().__init__()
@@ -2232,7 +2256,7 @@ class SDFGridMean(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     width : InputInteger
         Width
@@ -2241,7 +2265,7 @@ class SDFGridMean(BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.width : IntegerSocket
         Width
@@ -2250,7 +2274,7 @@ class SDFGridMean(BaseNode):
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -2258,7 +2282,7 @@ class SDFGridMean(BaseNode):
     node: bpy.types.GeometryNodeSDFGridMean
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
         width: IntegerSocket
         """Width"""
@@ -2278,7 +2302,7 @@ class SDFGridMean(BaseNode):
 
     def __init__(
         self,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
     ):
@@ -2294,21 +2318,21 @@ class SDFGridMeanCurvature(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     iterations : InputInteger
         Iterations
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.iterations : IntegerSocket
         Iterations
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -2316,7 +2340,7 @@ class SDFGridMeanCurvature(BaseNode):
     node: bpy.types.GeometryNodeSDFGridMeanCurvature
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
         iterations: IntegerSocket
         """Iterations"""
@@ -2334,7 +2358,7 @@ class SDFGridMeanCurvature(BaseNode):
 
     def __init__(
         self,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         iterations: InputInteger = 1,
     ):
         super().__init__()
@@ -2349,7 +2373,7 @@ class SDFGridMedian(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     width : InputInteger
         Width
@@ -2358,7 +2382,7 @@ class SDFGridMedian(BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.width : IntegerSocket
         Width
@@ -2367,7 +2391,7 @@ class SDFGridMedian(BaseNode):
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -2375,7 +2399,7 @@ class SDFGridMedian(BaseNode):
     node: bpy.types.GeometryNodeSDFGridMedian
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
         width: IntegerSocket
         """Width"""
@@ -2395,7 +2419,7 @@ class SDFGridMedian(BaseNode):
 
     def __init__(
         self,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         width: InputInteger = 1,
         iterations: InputInteger = 1,
     ):
@@ -2411,21 +2435,21 @@ class SDFGridOffset(BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     distance : InputFloat
         Distance
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.distance : FloatSocket
         Distance
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -2433,7 +2457,7 @@ class SDFGridOffset(BaseNode):
     node: bpy.types.GeometryNodeSDFGridOffset
 
     class _Inputs(SocketAccessor):
-        grid: FloatSocket
+        grid: FloatSocketGrid
         """Grid"""
         distance: FloatSocket
         """Distance"""
@@ -2451,7 +2475,7 @@ class SDFGridOffset(BaseNode):
 
     def __init__(
         self,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         distance: InputFloat = 0.1,
     ):
         super().__init__()
@@ -2460,13 +2484,13 @@ class SDFGridOffset(BaseNode):
         self._establish_links(**key_args)
 
 
-class SampleGrid[T](BaseNode):
+class SampleGrid[T, TGrid](BaseNode):
     """
     Retrieve values from the specified volume grid
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     position : InputVector
         Position
@@ -2475,7 +2499,7 @@ class SampleGrid[T](BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.position : VectorSocket
         Position
@@ -2491,28 +2515,28 @@ class SampleGrid[T](BaseNode):
     _bl_idname = "GeometryNodeSampleGrid"
     node: bpy.types.GeometryNodeSampleGrid
 
-    class _Inputs[S](SocketAccessor):
-        grid: S
+    class _Inputs[S, SGrid](SocketAccessor):
+        grid: SGrid
         """Grid"""
         position: VectorSocket
         """Position"""
         interpolation: MenuSocket
         """Interpolation"""
 
-    class _Outputs[S](SocketAccessor):
+    class _Outputs[S, SGrid](SocketAccessor):
         value: S
         """Value"""
 
     if TYPE_CHECKING:
 
         @property
-        def i(self) -> _Inputs[T]: ...
+        def i(self) -> _Inputs[T, TGrid]: ...
         @property
-        def o(self) -> _Outputs[T]: ...
+        def o(self) -> _Outputs[T, TGrid]: ...
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         position: InputVector = None,
         interpolation: InputMenu
         | Literal["Nearest Neighbor", "Trilinear", "Triquadratic"] = "Trilinear",
@@ -2527,11 +2551,11 @@ class SampleGrid[T](BaseNode):
     @classmethod
     def float(
         cls,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         position: InputVector = None,
         interpolation: InputMenu
         | Literal["Nearest Neighbor", "Trilinear", "Triquadratic"] = "Trilinear",
-    ) -> "SampleGrid[FloatSocket]":
+    ) -> "SampleGrid[FloatSocket, FloatSocketGrid]":
         """Create Sample Grid with operation 'Float'."""
         return SampleGrid(
             data_type="FLOAT", grid=grid, position=position, interpolation=interpolation
@@ -2540,11 +2564,11 @@ class SampleGrid[T](BaseNode):
     @classmethod
     def integer(
         cls,
-        grid: InputInteger = 0,
+        grid: InputIntegerGrid = None,
         position: InputVector = None,
         interpolation: InputMenu
         | Literal["Nearest Neighbor", "Trilinear", "Triquadratic"] = "Trilinear",
-    ) -> "SampleGrid[IntegerSocket]":
+    ) -> "SampleGrid[IntegerSocket, IntegerSocketGrid]":
         """Create Sample Grid with operation 'Integer'."""
         return SampleGrid(
             data_type="INT", grid=grid, position=position, interpolation=interpolation
@@ -2553,11 +2577,11 @@ class SampleGrid[T](BaseNode):
     @classmethod
     def boolean(
         cls,
-        grid: InputBoolean = False,
+        grid: InputBooleanGrid = None,
         position: InputVector = None,
         interpolation: InputMenu
         | Literal["Nearest Neighbor", "Trilinear", "Triquadratic"] = "Trilinear",
-    ) -> "SampleGrid[BooleanSocket]":
+    ) -> "SampleGrid[BooleanSocket, BooleanSocketGrid]":
         """Create Sample Grid with operation 'Boolean'."""
         return SampleGrid(
             data_type="BOOLEAN",
@@ -2569,11 +2593,11 @@ class SampleGrid[T](BaseNode):
     @classmethod
     def vector(
         cls,
-        grid: InputVector = None,
+        grid: InputVectorGrid = None,
         position: InputVector = None,
         interpolation: InputMenu
         | Literal["Nearest Neighbor", "Trilinear", "Triquadratic"] = "Trilinear",
-    ) -> "SampleGrid[VectorSocket]":
+    ) -> "SampleGrid[VectorSocket, VectorSocketGrid]":
         """Create Sample Grid with operation 'Vector'."""
         return SampleGrid(
             data_type="VECTOR",
@@ -2591,13 +2615,13 @@ class SampleGrid[T](BaseNode):
         self.node.data_type = value
 
 
-class SampleGridIndex[T](BaseNode):
+class SampleGridIndex[T, TGrid](BaseNode):
     """
     Retrieve volume grid values at specific voxels
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     x : InputInteger
         X
@@ -2608,7 +2632,7 @@ class SampleGridIndex[T](BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.x : IntegerSocket
         X
@@ -2626,8 +2650,8 @@ class SampleGridIndex[T](BaseNode):
     _bl_idname = "GeometryNodeSampleGridIndex"
     node: bpy.types.GeometryNodeSampleGridIndex
 
-    class _Inputs[S](SocketAccessor):
-        grid: S
+    class _Inputs[S, SGrid](SocketAccessor):
+        grid: SGrid
         """Grid"""
         x: IntegerSocket
         """X"""
@@ -2636,20 +2660,20 @@ class SampleGridIndex[T](BaseNode):
         z: IntegerSocket
         """Z"""
 
-    class _Outputs[S](SocketAccessor):
+    class _Outputs[S, SGrid](SocketAccessor):
         value: S
         """Value"""
 
     if TYPE_CHECKING:
 
         @property
-        def i(self) -> _Inputs[T]: ...
+        def i(self) -> _Inputs[T, TGrid]: ...
         @property
-        def o(self) -> _Outputs[T]: ...
+        def o(self) -> _Outputs[T, TGrid]: ...
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         x: InputInteger = 0,
         y: InputInteger = 0,
         z: InputInteger = 0,
@@ -2664,44 +2688,44 @@ class SampleGridIndex[T](BaseNode):
     @classmethod
     def float(
         cls,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         x: InputInteger = 0,
         y: InputInteger = 0,
         z: InputInteger = 0,
-    ) -> "SampleGridIndex[FloatSocket]":
+    ) -> "SampleGridIndex[FloatSocket, FloatSocketGrid]":
         """Create Sample Grid Index with operation 'Float'."""
         return SampleGridIndex(data_type="FLOAT", grid=grid, x=x, y=y, z=z)
 
     @classmethod
     def integer(
         cls,
-        grid: InputInteger = 0,
+        grid: InputIntegerGrid = None,
         x: InputInteger = 0,
         y: InputInteger = 0,
         z: InputInteger = 0,
-    ) -> "SampleGridIndex[IntegerSocket]":
+    ) -> "SampleGridIndex[IntegerSocket, IntegerSocketGrid]":
         """Create Sample Grid Index with operation 'Integer'."""
         return SampleGridIndex(data_type="INT", grid=grid, x=x, y=y, z=z)
 
     @classmethod
     def boolean(
         cls,
-        grid: InputBoolean = False,
+        grid: InputBooleanGrid = None,
         x: InputInteger = 0,
         y: InputInteger = 0,
         z: InputInteger = 0,
-    ) -> "SampleGridIndex[BooleanSocket]":
+    ) -> "SampleGridIndex[BooleanSocket, BooleanSocketGrid]":
         """Create Sample Grid Index with operation 'Boolean'."""
         return SampleGridIndex(data_type="BOOLEAN", grid=grid, x=x, y=y, z=z)
 
     @classmethod
     def vector(
         cls,
-        grid: InputVector = None,
+        grid: InputVectorGrid = None,
         x: InputInteger = 0,
         y: InputInteger = 0,
         z: InputInteger = 0,
-    ) -> "SampleGridIndex[VectorSocket]":
+    ) -> "SampleGridIndex[VectorSocket, VectorSocketGrid]":
         """Create Sample Grid Index with operation 'Vector'."""
         return SampleGridIndex(data_type="VECTOR", grid=grid, x=x, y=y, z=z)
 
@@ -2714,13 +2738,13 @@ class SampleGridIndex[T](BaseNode):
         self.node.data_type = value
 
 
-class SetGridBackground[T](BaseNode):
+class SetGridBackground[T, TGrid](BaseNode):
     """
     Set the background value used for inactive voxels and tiles
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     background : InputFloat
         Background
@@ -2729,7 +2753,7 @@ class SetGridBackground[T](BaseNode):
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.background : FloatSocket
         Background
@@ -2738,35 +2762,35 @@ class SetGridBackground[T](BaseNode):
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
     _bl_idname = "GeometryNodeSetGridBackground"
     node: bpy.types.GeometryNodeSetGridBackground
 
-    class _Inputs[S](SocketAccessor):
-        grid: S
+    class _Inputs[S, SGrid](SocketAccessor):
+        grid: SGrid
         """Grid"""
         background: S
         """Background"""
         update_inactive: BooleanSocket
         """Update Inactive"""
 
-    class _Outputs[S](SocketAccessor):
-        grid: S
+    class _Outputs[S, SGrid](SocketAccessor):
+        grid: SGrid
         """Grid"""
 
     if TYPE_CHECKING:
 
         @property
-        def i(self) -> _Inputs[T]: ...
+        def i(self) -> _Inputs[T, TGrid]: ...
         @property
-        def o(self) -> _Outputs[T]: ...
+        def o(self) -> _Outputs[T, TGrid]: ...
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         background: InputAny = 0.0,
         update_inactive: InputBoolean = False,
         *,
@@ -2784,10 +2808,10 @@ class SetGridBackground[T](BaseNode):
     @classmethod
     def float(
         cls,
-        grid: InputFloat = 0.0,
+        grid: InputFloatGrid = None,
         background: InputFloat = 0.0,
         update_inactive: InputBoolean = False,
-    ) -> "SetGridBackground[FloatSocket]":
+    ) -> "SetGridBackground[FloatSocket, FloatSocketGrid]":
         """Create Set Grid Background with operation 'Float'."""
         return SetGridBackground(
             data_type="FLOAT",
@@ -2799,10 +2823,10 @@ class SetGridBackground[T](BaseNode):
     @classmethod
     def integer(
         cls,
-        grid: InputInteger = 0,
+        grid: InputIntegerGrid = None,
         background: InputInteger = 0,
         update_inactive: InputBoolean = False,
-    ) -> "SetGridBackground[IntegerSocket]":
+    ) -> "SetGridBackground[IntegerSocket, IntegerSocketGrid]":
         """Create Set Grid Background with operation 'Integer'."""
         return SetGridBackground(
             data_type="INT",
@@ -2814,10 +2838,10 @@ class SetGridBackground[T](BaseNode):
     @classmethod
     def boolean(
         cls,
-        grid: InputBoolean = False,
+        grid: InputBooleanGrid = None,
         background: InputBoolean = False,
         update_inactive: InputBoolean = False,
-    ) -> "SetGridBackground[BooleanSocket]":
+    ) -> "SetGridBackground[BooleanSocket, BooleanSocketGrid]":
         """Create Set Grid Background with operation 'Boolean'."""
         return SetGridBackground(
             data_type="BOOLEAN",
@@ -2829,10 +2853,10 @@ class SetGridBackground[T](BaseNode):
     @classmethod
     def vector(
         cls,
-        grid: InputVector = None,
+        grid: InputVectorGrid = None,
         background: InputVector = None,
         update_inactive: InputBoolean = False,
-    ) -> "SetGridBackground[VectorSocket]":
+    ) -> "SetGridBackground[VectorSocket, VectorSocketGrid]":
         """Create Set Grid Background with operation 'Vector'."""
         return SetGridBackground(
             data_type="VECTOR",
@@ -2856,14 +2880,14 @@ class SetGridTransform[T](BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
     transform : InputMatrix
         Transform
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
     i.transform : MatrixSocket
         Transform
@@ -2872,7 +2896,7 @@ class SetGridTransform[T](BaseNode):
     -------
     o.is_valid : BooleanSocket
         Is Valid
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -2900,7 +2924,7 @@ class SetGridTransform[T](BaseNode):
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         transform: InputMatrix = None,
         *,
         data_type: Literal["FLOAT", "INT", "BOOLEAN", "VECTOR"] = "FLOAT",
@@ -2912,29 +2936,29 @@ class SetGridTransform[T](BaseNode):
 
     @classmethod
     def float(
-        cls, grid: InputFloat = 0.0, transform: InputMatrix = None
-    ) -> "SetGridTransform[FloatSocket]":
+        cls, grid: InputFloatGrid = None, transform: InputMatrix = None
+    ) -> "SetGridTransform[FloatSocketGrid]":
         """Create Set Grid Transform with operation 'Float'."""
         return SetGridTransform(data_type="FLOAT", grid=grid, transform=transform)
 
     @classmethod
     def integer(
-        cls, grid: InputInteger = 0, transform: InputMatrix = None
-    ) -> "SetGridTransform[IntegerSocket]":
+        cls, grid: InputIntegerGrid = None, transform: InputMatrix = None
+    ) -> "SetGridTransform[IntegerSocketGrid]":
         """Create Set Grid Transform with operation 'Integer'."""
         return SetGridTransform(data_type="INT", grid=grid, transform=transform)
 
     @classmethod
     def boolean(
-        cls, grid: InputBoolean = False, transform: InputMatrix = None
-    ) -> "SetGridTransform[BooleanSocket]":
+        cls, grid: InputBooleanGrid = None, transform: InputMatrix = None
+    ) -> "SetGridTransform[BooleanSocketGrid]":
         """Create Set Grid Transform with operation 'Boolean'."""
         return SetGridTransform(data_type="BOOLEAN", grid=grid, transform=transform)
 
     @classmethod
     def vector(
-        cls, grid: InputVector = None, transform: InputMatrix = None
-    ) -> "SetGridTransform[VectorSocket]":
+        cls, grid: InputVectorGrid = None, transform: InputMatrix = None
+    ) -> "SetGridTransform[VectorSocketGrid]":
         """Create Set Grid Transform with operation 'Vector'."""
         return SetGridTransform(data_type="VECTOR", grid=grid, transform=transform)
 
@@ -2957,7 +2981,7 @@ class StoreNamedGrid[T](BaseNode):
         Volume
     name : InputString
         Name
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
 
     Inputs
@@ -2966,7 +2990,7 @@ class StoreNamedGrid[T](BaseNode):
         Volume
     i.name : StringSocket
         Name
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
 
     Outputs
@@ -3001,7 +3025,7 @@ class StoreNamedGrid[T](BaseNode):
         self,
         volume: InputGeometry = None,
         name: InputString = "",
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         *,
         data_type: Literal["BOOLEAN", "FLOAT", "INT", "VECTOR_FLOAT"] = "FLOAT",
     ):
@@ -3015,8 +3039,8 @@ class StoreNamedGrid[T](BaseNode):
         cls,
         volume: InputGeometry = None,
         name: InputString = "",
-        grid: InputBoolean = False,
-    ) -> "StoreNamedGrid[BooleanSocket]":
+        grid: InputBooleanGrid = None,
+    ) -> "StoreNamedGrid[BooleanSocketGrid]":
         """Create Store Named Grid with operation 'Boolean'. Boolean"""
         return StoreNamedGrid(data_type="BOOLEAN", volume=volume, name=name, grid=grid)
 
@@ -3025,8 +3049,8 @@ class StoreNamedGrid[T](BaseNode):
         cls,
         volume: InputGeometry = None,
         name: InputString = "",
-        grid: InputFloat = 0.0,
-    ) -> "StoreNamedGrid[FloatSocket]":
+        grid: InputFloatGrid = None,
+    ) -> "StoreNamedGrid[FloatSocketGrid]":
         """Create Store Named Grid with operation 'Float'. Single precision float"""
         return StoreNamedGrid(data_type="FLOAT", volume=volume, name=name, grid=grid)
 
@@ -3035,8 +3059,8 @@ class StoreNamedGrid[T](BaseNode):
         cls,
         volume: InputGeometry = None,
         name: InputString = "",
-        grid: InputInteger = 0,
-    ) -> "StoreNamedGrid[IntegerSocket]":
+        grid: InputIntegerGrid = None,
+    ) -> "StoreNamedGrid[IntegerSocketGrid]":
         """Create Store Named Grid with operation 'Integer'. 32-bit integer"""
         return StoreNamedGrid(data_type="INT", volume=volume, name=name, grid=grid)
 
@@ -3045,8 +3069,8 @@ class StoreNamedGrid[T](BaseNode):
         cls,
         volume: InputGeometry = None,
         name: InputString = "",
-        grid: InputVector = None,
-    ) -> "StoreNamedGrid[VectorSocket]":
+        grid: InputVectorGrid = None,
+    ) -> "StoreNamedGrid[VectorSocketGrid]":
         """Create Store Named Grid with operation 'Vector'. 3D float vector"""
         return StoreNamedGrid(
             data_type="VECTOR_FLOAT", volume=volume, name=name, grid=grid
@@ -3255,17 +3279,17 @@ class VoxelizeGrid[T](BaseNode):
 
     Parameters
     ----------
-    grid : InputFloat
+    grid : InputFloatGrid
         Grid
 
     Inputs
     ------
-    i.grid : FloatSocket
+    i.grid : FloatSocketGrid
         Grid
 
     Outputs
     -------
-    o.grid : FloatSocket
+    o.grid : FloatSocketGrid
         Grid
     """
 
@@ -3289,7 +3313,7 @@ class VoxelizeGrid[T](BaseNode):
 
     def __init__(
         self,
-        grid: InputAny = 0.0,
+        grid: InputAny = None,
         *,
         data_type: Literal["FLOAT", "INT", "BOOLEAN", "VECTOR"] = "FLOAT",
     ):
@@ -3299,22 +3323,26 @@ class VoxelizeGrid[T](BaseNode):
         self._establish_links(**key_args)
 
     @classmethod
-    def float(cls, grid: InputFloat = 0.0) -> "VoxelizeGrid[FloatSocket]":
+    def float(cls, grid: InputFloatGrid = None) -> "VoxelizeGrid[FloatSocketGrid]":
         """Create Voxelize Grid with operation 'Float'."""
         return VoxelizeGrid(data_type="FLOAT", grid=grid)
 
     @classmethod
-    def integer(cls, grid: InputInteger = 0) -> "VoxelizeGrid[IntegerSocket]":
+    def integer(
+        cls, grid: InputIntegerGrid = None
+    ) -> "VoxelizeGrid[IntegerSocketGrid]":
         """Create Voxelize Grid with operation 'Integer'."""
         return VoxelizeGrid(data_type="INT", grid=grid)
 
     @classmethod
-    def boolean(cls, grid: InputBoolean = False) -> "VoxelizeGrid[BooleanSocket]":
+    def boolean(
+        cls, grid: InputBooleanGrid = None
+    ) -> "VoxelizeGrid[BooleanSocketGrid]":
         """Create Voxelize Grid with operation 'Boolean'."""
         return VoxelizeGrid(data_type="BOOLEAN", grid=grid)
 
     @classmethod
-    def vector(cls, grid: InputVector = None) -> "VoxelizeGrid[VectorSocket]":
+    def vector(cls, grid: InputVectorGrid = None) -> "VoxelizeGrid[VectorSocketGrid]":
         """Create Voxelize Grid with operation 'Vector'."""
         return VoxelizeGrid(data_type="VECTOR", grid=grid)
 

--- a/src/nodebpy/nodes/geometry/input.py
+++ b/src/nodebpy/nodes/geometry/input.py
@@ -400,9 +400,9 @@ class CollectionChildren(BaseNode):
 
     Outputs
     -------
-    o.collections : CollectionSocket
+    o.collections : CollectionSocketList
         Collections
-    o.objects : ObjectSocket
+    o.objects : ObjectSocketList
         Objects
     """
 

--- a/tests/__snapshots__/test_tree.ambr
+++ b/tests/__snapshots__/test_tree.ambr
@@ -25,7 +25,7 @@
       with g.Frame("SVD"):
           matrix_svd = combine_matrix.o.matrix.svd()
           separate_matrix = g.SeparateMatrix(matrix=matrix_svd.u)
-          combine_xyz = g.CombineXYZ(x=separate_matrix, y=separate_matrix.o.column_1_row_2, z=separate_matrix.o.column_1_row_3)
+          combine_xyz = g.CombineXYZ(x=separate_matrix.o.column_1_row_1, y=separate_matrix.o.column_1_row_2, z=separate_matrix.o.column_1_row_3)
           combine_xyz_1 = g.CombineXYZ(x=separate_matrix.o.column_2_row_1, y=separate_matrix.o.column_2_row_2, z=separate_matrix.o.column_2_row_3)
           combine_xyz_2 = g.CombineXYZ(x=separate_matrix.o.column_3_row_1, y=separate_matrix.o.column_3_row_2, z=separate_matrix.o.column_3_row_3)
           axes_to_rotation = g.AxesToRotation(primary_axis=combine_xyz, secondary_axis=combine_xyz_2)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -488,6 +488,26 @@ def test_keep_reroutes_with_snapshot_positions():
     assert f'"{reroute.name}": (360.0, 120.0)' in code  # reroute position kept
 
 
+def test_type_factories_emitted_at_defaults():
+    """Factories baked purely over type-defining props (data_type, domain,
+    input_type, …) render even when every baked value sits at its default —
+    the data type is load-bearing, so it stays explicit. Generic: any node
+    with such factories qualifies, including ones whose factory bodies pass
+    sockets positionally (FieldMinAndMax)."""
+    with TreeBuilder("AttrDefaults") as tree:
+        geo = tree.inputs.geometry("Geometry")
+        value = g.NamedAttribute("radius")
+        stored = g.StoreNamedAttribute(geometry=geo, name="radius", value=value)
+        minmax = g.FieldMinAndMax()  # unlinked: factory, not a socket method
+        g.Math.add(minmax.o.min, 0.0)
+        stored >> tree.outputs.geometry("Out")
+
+    code = _assert_roundtrip(tree)
+    assert 'g.NamedAttribute.float("radius")' in code
+    assert "g.StoreNamedAttribute.point.float(" in code
+    assert "g.FieldMinAndMax.point.float()" in code
+
+
 def test_snapshot_positions_nested_group_round_trip():
     """snapshot_positions restores locations inside nested group classes too:
     the generated ``_build_group`` disables its own auto-layout and applies a
@@ -927,11 +947,9 @@ def test_switch_emits_socket_method():
 
 
 def test_switch_unlinked_condition_falls_back():
-    """Switch with no linked condition can't be a method — constructor/factory.
-
-    FLOAT is the default input_type, so the plain constructor suffices; a
-    non-default type (geometry) uses the factory spelling.
-    """
+    """Switch with no linked condition can't be a method — it renders as the
+    typed factory, even for the default FLOAT input type: type-defining
+    factories always keep the data type explicit."""
     with TreeBuilder("SwitchFactory") as tree:
         a = tree.inputs.float("A", 1.0)
         b = tree.inputs.float("B", 2.0)
@@ -939,7 +957,7 @@ def test_switch_unlinked_condition_falls_back():
         geo = tree.inputs.geometry("Geo")
         g.Switch.geometry(None, None, geo) >> tree.outputs.geometry("GeoOut")
     code = _assert_roundtrip(tree)
-    assert "g.Switch(false=a, true=b)" in code
+    assert "g.Switch.float(false=a, true=b)" in code
     assert "g.Switch.geometry(true=geo)" in code
 
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1192,7 +1192,7 @@ def test_factory_keeps_default_prop_constructor():
     with TreeBuilder("PlainMath") as tree:
         g.Math()  # ADD is the default operation
     code = to_python(tree)
-    assert "math = g.Math()" in code
+    assert "math_1 = g.Math()" in code
 
 
 # ---------------------------------------------------------------------------
@@ -2307,7 +2307,7 @@ def test_long_expressions_split_into_variables():
     code = _assert_roundtrip(tree)
     body = [line for line in code.splitlines() if line.strip()]
     assert all(len(line) <= 110 for line in body), code
-    assert any(line.strip().startswith("math = ") for line in body), code
+    assert any(line.strip().startswith("math_1 = ") for line in body), code
 
     # format=False so ruff doesn't re-wrap the long line we're asserting on.
     unbudgeted = to_python(tree, max_inline_width=None, format=False)


### PR DESCRIPTION
Splits the standalone cleanup/fix commits out of #140 so the feature PR can focus on the dump/build overhaul. Cherry-picked from `asset-dump-build` (version bumps dropped; one test assertion adjusted where it depended on feature-branch behavior):

- **tweak codegen to favor classmethods** — type-defining factories (`g.Switch.float`, `g.StoreNamedAttribute.point.float`, …) stay explicit even when every baked value is at its default.
- **Fix gen/ module typing sockets with List/Grid subtypes** — generator fix plus regenerated `converter.py` / `grid.py` / `geometry.py`.
- **sometimes more explicit output socket in codegen**
- **fix normalisation of letters** — in `gen/util.py` and `builder/_utils.py`.
- **nicer printing of math.pi, 10_000 and rounding floats** — `math.pi`/`math.tau`/`math.e` recognition within one ULP, digit grouping, float32 round-tripping; `math`/`bpy` names are kept off-limits for generated variables.

Once this merges, merging `main` back into `asset-dump-build` shrinks #140 accordingly.
