### PR TITLE
Typed _build_group signatures; lint-clean generated output

### DIFF
--- a/docs/assets.qmd
+++ b/docs/assets.qmd
@@ -75,7 +75,7 @@ generate_asset_modules(
 Because asset names repeat across editors, splitting also keeps the generated
 class names collision-free where a single mixed module would silently shadow
 one tree type's class with another's.
-=======
+
 ### Docstrings and menu types
 
 By default the generated classes carry numpy-style docstrings built from the

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -14,6 +14,8 @@ title: Changelog
 - **Same-named sibling panels** — Blender allows several same-named panels under one parent; `tree.panel(...)` gained `reuse=False` (create a fresh panel instead of reusing) and accepts an existing panel (or a previous `tree.panel(...)` context) to reopen exactly that panel. Codegen uses both spellings so such interfaces rebuild without folding panels together, and empty organizational panels are now emitted too. A mixed `tree.panel` inside `tree.outputs.panel(...)` now nests under it correctly and restores each direction's own active panel on exit.
 - Interface menu defaults assigned after the `with TreeBuilder(...)` block exits now apply immediately instead of queueing forever, and reading `menu.default_value` reports the pending or applied interface value instead of the stale node socket.
 - Interface `Font` / `Sound` socket defaults are now dumped and rebuilt like the other datablock defaults, and `is_strip_modifier` joined the round-tripped tree-level properties.
+- **Typed `_build_group` signatures** — generated classes annotate the builder parameter per tree type (`def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:`), importing the `bpy.types` tree class, so the whole method body type-checks and autocompletes in editors; `NodeGroupBuilder._build_group` itself is now typed `TreeBuilder[T]`, so hand-written `Custom*Group` subclasses inherit the narrowed hint too.
+- **Lint-clean generated output** — formatted output now runs `ruff check --fix` *and* `ruff format` as it is written (sorted imports, double-quoted strings, `**{...}` collapsed to plain kwargs where socket names allow), so dumped sources need no lint pass afterwards; the dump's metadata footers and library references emit double-quoted strings directly.
 - Exposed the `TrimString` node via `StringSocket.trim()`, with codegen round-tripping trees back to the method call
 - Exposed the `StringToValue` node via `StringSocket.to_float()` / `.to_integer(base)`, and `IntegerSocket.to_string()` now exposes the node's `base` and `padding` options
 - `to_python` now round-trips `split()`, `to_float()` / `to_integer()` and float/integer `to_string()` as socket method calls instead of `g.SplitString(...)` / `g.StringToValue.*(...)` / `g.ValueToString.*(...)` factory calls
@@ -25,6 +27,7 @@ title: Changelog
 - Referencing one of several same-named outputs on a *group* node used an identifier-derived accessor name (`group.o.socket_0`) that broke on rebuild — such outputs are now referenced by position (`group.o[2]`), which the interface order preserves.
 - `value.map_range(...)` with a non-default steps value emitted five positional arguments where `steps` is keyword-only, making the generated script fail to run.
 - An IntegerMath operation with a float operand was lifted to a Python operator that rebuilt as a float `ShaderNodeMath` node; the lift now checks operand types like the other math lifts.
+- Codegen's value formatter rendered a one-element tuple without its trailing comma (`("X")` — a plain string), so any single-entry sequence value degenerated on rebuild; it now keeps the comma.
 
 ## v520.15.0 - 2026-08-28
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,7 +2,18 @@
 title: Changelog
 ---
 
-## UNRELEASED
+## v250.18.0 - UNRELEASED
+
+### Enhancements
+
+- **Typed `_build_group` signatures** — generated classes annotate the builder parameter per tree type (`def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:`), importing the `bpy.types` tree class, so the whole method body type-checks and autocompletes in editors; `NodeGroupBuilder._build_group` itself is now typed `TreeBuilder[T]`, so hand-written `Custom*Group` subclasses inherit the narrowed hint too.
+- **Lint-clean generated output** — formatted output now runs `ruff check --fix` *and* `ruff format` as it is written (sorted imports, double-quoted strings, `**{...}` collapsed to plain kwargs where socket names allow), so dumped sources need no lint pass afterwards; the dump's metadata footers and library references emit double-quoted strings directly.
+
+### Fixes
+
+- Codegen's value formatter rendered a one-element tuple without its trailing comma (`("X")` — a plain string), so any single-entry sequence value degenerated on rebuild; it now keeps the comma.
+
+## v250.17.0 - 2026-09-10
 
 ### Enhancements
 
@@ -14,8 +25,6 @@ title: Changelog
 - **Same-named sibling panels** — Blender allows several same-named panels under one parent; `tree.panel(...)` gained `reuse=False` (create a fresh panel instead of reusing) and accepts an existing panel (or a previous `tree.panel(...)` context) to reopen exactly that panel. Codegen uses both spellings so such interfaces rebuild without folding panels together, and empty organizational panels are now emitted too. A mixed `tree.panel` inside `tree.outputs.panel(...)` now nests under it correctly and restores each direction's own active panel on exit.
 - Interface menu defaults assigned after the `with TreeBuilder(...)` block exits now apply immediately instead of queueing forever, and reading `menu.default_value` reports the pending or applied interface value instead of the stale node socket.
 - Interface `Font` / `Sound` socket defaults are now dumped and rebuilt like the other datablock defaults, and `is_strip_modifier` joined the round-tripped tree-level properties.
-- **Typed `_build_group` signatures** — generated classes annotate the builder parameter per tree type (`def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:`), importing the `bpy.types` tree class, so the whole method body type-checks and autocompletes in editors; `NodeGroupBuilder._build_group` itself is now typed `TreeBuilder[T]`, so hand-written `Custom*Group` subclasses inherit the narrowed hint too.
-- **Lint-clean generated output** — formatted output now runs `ruff check --fix` *and* `ruff format` as it is written (sorted imports, double-quoted strings, `**{...}` collapsed to plain kwargs where socket names allow), so dumped sources need no lint pass afterwards; the dump's metadata footers and library references emit double-quoted strings directly.
 - Exposed the `TrimString` node via `StringSocket.trim()`, with codegen round-tripping trees back to the method call
 - Exposed the `StringToValue` node via `StringSocket.to_float()` / `.to_integer(base)`, and `IntegerSocket.to_string()` now exposes the node's `base` and `padding` options
 - `to_python` now round-trips `split()`, `to_float()` / `to_integer()` and float/integer `to_string()` as socket method calls instead of `g.SplitString(...)` / `g.StringToValue.*(...)` / `g.ValueToString.*(...)` factory calls
@@ -27,7 +36,6 @@ title: Changelog
 - Referencing one of several same-named outputs on a *group* node used an identifier-derived accessor name (`group.o.socket_0`) that broke on rebuild — such outputs are now referenced by position (`group.o[2]`), which the interface order preserves.
 - `value.map_range(...)` with a non-default steps value emitted five positional arguments where `steps` is keyword-only, making the generated script fail to run.
 - An IntegerMath operation with a float operand was lifted to a Python operator that rebuilt as a float `ShaderNodeMath` node; the lift now checks operand types like the other math lifts.
-- Codegen's value formatter rendered a one-element tuple without its trailing comma (`("X")` — a plain string), so any single-entry sequence value degenerated on rebuild; it now keeps the comma.
 
 ## v520.15.0 - 2026-08-28
 

--- a/src/nodebpy/assets/_codegen.py
+++ b/src/nodebpy/assets/_codegen.py
@@ -290,7 +290,7 @@ def _introspect(library: AssetLibrary, names: set[str] | None) -> list[_AssetCla
 def _library_source(library: AssetLibrary) -> str:
     """Source expression that reconstructs ``library`` in the generated module."""
     if isinstance(library, BundledLibrary):
-        return f"BundledLibrary({library.filename!r})"
+        return f"BundledLibrary({_fmt(library.filename)})"
     from ..builder import PackageLibrary
 
     if isinstance(library, PackageLibrary):
@@ -298,7 +298,7 @@ def _library_source(library: AssetLibrary) -> str:
         # so the generated module imports cleanly and stays cross-platform even
         # when ``relative`` was passed as a ``Path``.
         relative = Path(library.relative).as_posix()
-        return f"PackageLibrary(__file__, {relative!r})"
+        return f"PackageLibrary(__file__, {_fmt(relative)})"
     raise TypeError(f"Cannot serialise asset library: {library!r}")
 
 
@@ -355,8 +355,8 @@ def _render_class(cls: _AssetClass, docstrings: bool = False) -> str:
     return f"""class {cls.class_name}({base}):
     {docstring}
 
-    _name = {cls.asset_name!r}
-    _asset_name = {cls.asset_name!r}
+    _name = {_fmt(cls.asset_name)}
+    _asset_name = {_fmt(cls.asset_name)}
     _library = {cls.library_source}
 
 {inputs_cls}
@@ -451,7 +451,7 @@ def interface_parts(
     if library_source:
         base = asset_group_base(cls.tree_idname).__name__
         attr_lines = [
-            f"_asset_name = {cls.asset_name!r}",
+            f"_asset_name = {_fmt(cls.asset_name)}",
             f"_library = {library_source}",
         ]
 

--- a/src/nodebpy/assets/_library.py
+++ b/src/nodebpy/assets/_library.py
@@ -74,6 +74,7 @@ from ..export.codegen import (
     _ID_COLLECTIONS,
     GroupInterface,
     _class_name,
+    _fmt,
     _format_with_ruff,
     to_python,
 )
@@ -215,7 +216,7 @@ def _id_defaults(tree) -> dict[str, set[str]]:
 
 def _dict_lines(name: str, data: dict[str, object]) -> list[str]:
     lines = [f"{name} = {{"]
-    lines += [f"    {key!r}: {value!r}," for key, value in data.items()]
+    lines += [f"    {_fmt(key)}: {_fmt(value)}," for key, value in data.items()]
     lines.append("}")
     return lines
 
@@ -336,9 +337,9 @@ def _render_group_module(
     # Deliberately no source filename/timestamp in the header: a dump must be
     # byte-identical across a no-op round-trip so it leaves no VCS diff.
     label = {
-        "asset": f"Node-group asset {group.name!r} ({group.bl_idname})",
-        "shared": f"Node group {group.name!r} ({group.bl_idname})",
-        "material": f"Material {material_name!r}",
+        "asset": f'Node-group asset "{group.name}" ({group.bl_idname})',
+        "shared": f'Node group "{group.name}" ({group.bl_idname})',
+        "material": f'Material "{material_name}"',
     }[kind]
     header = [
         f"# {label}, dumped by nodebpy.assets.dump_library.",
@@ -375,7 +376,7 @@ def _render_group_module(
             "",
             "",
             f"MATERIAL = {class_name}",
-            f"MATERIAL_NAME = {material_name!r}",
+            f"MATERIAL_NAME = {_fmt(material_name)}",
         ]
         material = bpy.data.materials[material_name]
         props = _material_properties(material)
@@ -773,7 +774,7 @@ def _dump_appended(
             if kind == "asset":
                 module_dir = (output_dir / module).parent
                 relpath = Path(os.path.relpath(library_blend, module_dir)).as_posix()
-                library_source = f"PackageLibrary(__file__, {relpath!r})"
+                library_source = f"PackageLibrary(__file__, {_fmt(relpath)})"
             root_interface, iface_imports = interface_parts(
                 group, library_source=library_source, nodebpy_pkg=nodebpy_pkg
             )

--- a/src/nodebpy/builder/node.py
+++ b/src/nodebpy/builder/node.py
@@ -455,7 +455,7 @@ class NodeGroupBuilder[T: bpy.types.NodeTree](BaseNode, ABC):
         ...
 
     @abstractmethod
-    def _build_group(self, tree: TreeBuilder) -> None:
+    def _build_group(self, tree: TreeBuilder[T]) -> None:
         """Build the node group internals and interface."""
 
     @classmethod

--- a/src/nodebpy/export/codegen.py
+++ b/src/nodebpy/export/codegen.py
@@ -485,9 +485,12 @@ def _fmt(value: Any) -> str:
     # Vectors / sequences
     try:
         items = list(value)
-        return f"({', '.join(_fmt(v) for v in items)})"
     except TypeError:
         return repr(value)
+    if len(items) == 1:
+        # The trailing comma keeps a one-element tuple a tuple.
+        return f"({_fmt(items[0])},)"
+    return f"({', '.join(_fmt(v) for v in items)})"
 
 
 def _eq(a: Any, b: Any) -> bool:
@@ -3652,8 +3655,10 @@ def _emit_interface_lines(node_tree, ctx: EmitContext) -> list[str]:
 
 
 def _format_with_ruff(code: str) -> str:
-    """Format ``code`` with ruff if the optional ``ruff`` package is installed,
-    otherwise return it unchanged.
+    """Run ``code`` through ``ruff check --fix-only`` and ``ruff format`` if
+    the optional ``ruff`` package is installed, otherwise return it unchanged
+    — so generated files come out already fixed and formatted rather than
+    needing a lint pass afterwards.
 
     Uses the binary bundled with the ``ruff`` Python package (via
     ``ruff.find_ruff_bin``), so it works wherever the package is importable —
@@ -3665,20 +3670,24 @@ def _format_with_ruff(code: str) -> str:
         return code
     import subprocess
 
-    try:
-        result = subprocess.run(
-            [find_ruff_bin(), "format", "-"],
-            input=code,
-            capture_output=True,
-            # Explicit UTF-8: text mode alone uses the locale encoding, and on
-            # Windows (cp1252) any non-ASCII character in the source reaches
-            # ruff as invalid UTF-8 — it errors and the code stays unformatted.
-            encoding="utf-8",
-            check=True,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return code
-    return result.stdout or code
+    ruff = find_ruff_bin()
+    for command in (["check", "--fix-only", "-"], ["format", "-"]):
+        try:
+            result = subprocess.run(
+                [ruff, *command],
+                input=code,
+                capture_output=True,
+                # Explicit UTF-8: text mode alone uses the locale encoding,
+                # and on Windows (cp1252) any non-ASCII character in the
+                # source reaches ruff as invalid UTF-8 — it errors and the
+                # code stays unformatted.
+                encoding="utf-8",
+                check=True,
+            )
+        except (OSError, subprocess.SubprocessError):  # pragma: no cover
+            return code
+        code = result.stdout or code
+    return code
 
 
 def to_python(
@@ -3811,10 +3820,17 @@ def to_python(
         for alias in ("g", "s", "c")
         if alias in used_aliases
     ]
-    # TreeBuilder is only referenced by the `with` block; class bodies use the
-    # ``tree`` parameter of ``_build_group`` instead.
-    import_names = import_parts + (["TreeBuilder"] if top_level == "with" else [])
+    # TreeBuilder anchors the `with` block and annotates every generated
+    # ``_build_group(self, tree: TreeBuilder)``, so editors type the whole
+    # body of a dumped class.
+    import_names = import_parts + ["TreeBuilder"]
     lines: list[str] = []
+    if collector.tree_param_types:
+        # The ``tree: TreeBuilder[GeometryNodeTree]`` annotations on emitted
+        # classes reference the bpy tree types by name.
+        lines.append(
+            "from bpy.types import " + ", ".join(sorted(collector.tree_param_types))
+        )
     if import_names:
         lines.append(f"from {nodebpy_pkg} import " + ", ".join(import_names))
     if collector.bases_used:
@@ -3850,9 +3866,9 @@ def to_python(
             lines.append("")
             lines.extend(_node_positions_lines(node_tree, indent=""))
 
-    # Datablock defaults (a Material/Object/Image socket value) render via
-    # ``repr()`` as ``bpy.data.<collection>['name']``, so the module needs a
-    # bare ``import bpy`` to resolve them on rebuild.
+    # Datablock defaults (a Material/Object/Image socket value) render as
+    # guarded ``bpy.data.<collection>.get("name")`` lookups, so the module
+    # needs a bare ``import bpy`` to resolve them on rebuild.
     # Math-constant expressions (from _fmt_float) need the stdlib import.
     if any(re.search(r"\bmath\.(pi|tau|e)\b", line) for line in lines):
         lines.insert(0, "import math")
@@ -4035,6 +4051,8 @@ class _GroupCollector:
     used_names: set[str] = field(default_factory=set)
     bases_used: set[str] = field(default_factory=set)
     used_aliases: set[str] = field(default_factory=set)
+    # bpy.types names the emitted ``tree: TreeBuilder[...]`` annotations need.
+    tree_param_types: set[str] = field(default_factory=set)
 
     def register(self, node_tree) -> str:
         """Ensure a class exists for ``node_tree`` and return its name."""
@@ -4057,6 +4075,10 @@ class _GroupCollector:
         if interface is not None and interface.base:
             base = interface.base
         self.bases_used.add(base)
+        if node_tree.bl_idname in _GROUP_BASE_FOR_TREE:
+            # A tree's bl_idname doubles as its bpy.types class name, which
+            # parameterizes the emitted ``tree: TreeBuilder[...]`` annotation.
+            self.tree_param_types.add(node_tree.bl_idname)
         self.class_defs.append(
             _render_group_class(
                 class_name,
@@ -4312,7 +4334,13 @@ def _render_group_class(
         header.append(f"    _tree_properties = {{{rendered}}}")
     if interface is not None:
         header.extend(["", interface.body])
-    header.extend(["", "    def _build_group(self, tree):"])
+    # The tree's bl_idname doubles as its bpy.types class name.
+    annotation = (
+        f"TreeBuilder[{node_tree.bl_idname}]"
+        if node_tree.bl_idname in _GROUP_BASE_FOR_TREE
+        else "TreeBuilder"
+    )
+    header.extend(["", f"    def _build_group(self, tree: {annotation}) -> None:"])
     inner = _assemble_tree_body(emission)
     # Either option needs auto-layout off (it dissolves reroutes and overwrites
     # locations); the disable line goes at the body's "in-block" 4-space indent,

--- a/tests/__snapshots__/test_codegen.ambr
+++ b/tests/__snapshots__/test_codegen.ambr
@@ -1,7 +1,8 @@
 # serializer version: 1
 # name: test_codegen_list_methods
   '''
-  from nodebpy import geometry as g, TreeBuilder
+  from nodebpy import TreeBuilder
+  from nodebpy import geometry as g
   
   with TreeBuilder("Geometry Node Group") as tree:
       filtered = tree.outputs.vector("Filtered")
@@ -137,6 +138,7 @@
 # ---
 # name: test_snapshot_positions_nested_group_block
   '''
+  from bpy.types import GeometryNodeTree
   from nodebpy import geometry as g, TreeBuilder
   from nodebpy.builder import CustomGeometryGroup
   
@@ -144,7 +146,7 @@
   class SnapInner(CustomGeometryGroup):
       _name = "SnapInner"
   
-      def _build_group(self, tree):
+      def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
           tree.disable_arrange()
   
           geometry = tree.inputs.geometry("Geometry")
@@ -195,14 +197,15 @@
 # ---
 # name: test_snapshot_top_level_class
   '''
-  from nodebpy import geometry as g
+  from bpy.types import GeometryNodeTree
+  from nodebpy import geometry as g, TreeBuilder
   from nodebpy.builder import CustomGeometryGroup
   
   
   class SnapClassInner(CustomGeometryGroup):
       _name = "SnapClassInner"
   
-      def _build_group(self, tree):
+      def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
           geometry = tree.inputs.geometry("Geometry")
           geometry_1 = tree.outputs.geometry("Geometry")
   
@@ -212,7 +215,7 @@
   class SnapClassOuter(CustomGeometryGroup):
       _name = "SnapClassOuter"
   
-      def _build_group(self, tree):
+      def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:
           geometry = tree.inputs.geometry("Geometry")
           geometry_1 = tree.outputs.geometry("Geometry")
   

--- a/tests/test_asset_library.py
+++ b/tests/test_asset_library.py
@@ -713,8 +713,11 @@ def test_typed_api_dump_merges_interface(nested_library_blend, tmp_path):
     assert f'_library = PackageLibrary(__file__, "{relpath}")' in outer_a
     assert "Parameters" in outer_a and "Outputs" in outer_a
     assert "class _Inputs(SocketAccessor):" in outer_a
-    assert 'super().__init__(**{"Geometry": geometry, "Factor": factor})' in outer_a
-    assert "def _build_group(self, tree):" in outer_a
+    assert "super().__init__(Geometry=geometry, Factor=factor)" in outer_a
+    assert (
+        "def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:"
+        in outer_a
+    )
     # Group calls inside _build_group use the typed parameter names.
     assert "InnerWidget(geometry=geometry, amount=Doubler(value=factor))" in outer_a
     assert "ASSET = OuterA" in outer_a
@@ -931,8 +934,11 @@ def test_compositor_roundtrip_plain_and_typed(tmp_path):
     typed = (first / "compositor" / "grade_boost.py").read_text(encoding="utf-8")
     assert "class GradeBoost(AssetCompositorGroup):" in typed
     assert '_library = PackageLibrary(__file__, "../../assets.blend")' in typed
-    assert 'super().__init__(**{"Image": image, "Boost": boost})' in typed
-    assert "def _build_group(self, tree):" in typed
+    assert "super().__init__(Image=image, Boost=boost)" in typed
+    assert (
+        "def _build_group(self, tree: TreeBuilder[CompositorNodeTree]) -> None:"
+        in typed
+    )
     init = (first / "compositor" / "__init__.py").read_text(encoding="utf-8")
     assert "from .grade_boost import GradeBoost" in init
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -187,7 +187,7 @@ def test_library_source_renders_path_as_plain_string():
     module doesn't import (and which isn't cross-platform)."""
     lib = PackageLibrary(__file__, Path("assets") / "data.blend")
     source = _codegen._library_source(lib)
-    assert source == "PackageLibrary(__file__, 'assets/data.blend')"
+    assert source == 'PackageLibrary(__file__, "assets/data.blend")'
     assert "PosixPath" not in source
     assert "WindowsPath" not in source
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -120,7 +120,8 @@ def test_boilerplate_imports():
     with TreeBuilder("Imports") as tree:
         g.Position()
     code = to_python(tree)
-    assert "from nodebpy import geometry as g, TreeBuilder" in code
+    assert "from nodebpy import TreeBuilder" in code
+    assert "from nodebpy import geometry as g" in code
 
 
 def test_with_interface_inputs():
@@ -374,8 +375,8 @@ def test_nodebpy_pkg_rewrites_import_anchor():
 
 def test_top_level_class_emits_class_not_with_block():
     """top_level='class' renders the working tree as a Custom*Group subclass
-    (no ``with`` block / TreeBuilder import); the default stays the ``with``
-    form."""
+    (no ``with`` block; TreeBuilder is imported only for the typed ``tree``
+    parameter); the default stays the ``with`` form."""
     with TreeBuilder("ArchiveMe") as tree:
         geo = tree.inputs.geometry("Geometry")
         g.SetPosition(geometry=geo) >> tree.outputs.geometry("Geometry")
@@ -384,9 +385,11 @@ def test_top_level_class_emits_class_not_with_block():
 
     code = to_python(tree, top_level="class")
     assert "class ArchiveMe(CustomGeometryGroup):" in code
-    assert "def _build_group(self, tree):" in code
+    assert (
+        "def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:" in code
+    )
     assert "with TreeBuilder(" not in code
-    assert "TreeBuilder" not in code  # not imported when unused
+    assert "from bpy.types import GeometryNodeTree" in code
 
 
 def test_top_level_class_round_trips_via_create_group():
@@ -1415,7 +1418,8 @@ def test_imports_only_used_aliases():
     with TreeBuilder("GeoOnly") as tree:
         g.Position()
     code = to_python(tree)
-    assert code.splitlines()[0] == "from nodebpy import geometry as g, TreeBuilder"
+    assert code.splitlines()[0] == "from nodebpy import TreeBuilder"
+    assert code.splitlines()[1] == "from nodebpy import geometry as g"
 
 
 def test_imports_no_alias_for_empty_tree():
@@ -2114,7 +2118,9 @@ def test_custom_group_emits_recursive_class():
     code = to_python(tree)
     assert "from nodebpy.builder import CustomGeometryGroup" in code
     assert "class ClipFieldToBox(CustomGeometryGroup):" in code
-    assert "def _build_group(self, tree):" in code
+    assert (
+        "def _build_group(self, tree: TreeBuilder[GeometryNodeTree]) -> None:" in code
+    )
     assert 'ClipFieldToBox(**{"Box Object": object})' in code
 
     orig_top = _structure(tree.tree)


### PR DESCRIPTION
Generated classes annotate the builder parameter per tree type (tree: TreeBuilder[GeometryNodeTree]), importing the bpy.types class, so the whole method body type-checks and autocompletes; the abstract NodeGroupBuilder._build_group is narrowed to TreeBuilder[T] so hand- written subclasses inherit the hint.

Formatted output now runs ruff check --fix as well as ruff format at write time (sorted imports, double quotes, **{...} collapsed to plain kwargs where socket names allow), and the dump's metadata footers and library references emit double-quoted strings directly via _fmt — which also fixes _fmt rendering one-element tuples without their trailing comma. Stray conflict marker in docs/assets.qmd removed.